### PR TITLE
Extend import statement to support Python 3

### DIFF
--- a/dash_html_components/__init__.py
+++ b/dash_html_components/__init__.py
@@ -1,7 +1,7 @@
 import os as _os
 import dash as _dash
 import sys as _sys
-from version import __version__
+from .version import __version__
 
 _current_path = _os.path.dirname(_os.path.abspath(__file__))
 


### PR DESCRIPTION
After configuring `tox` for [dash2](https://github.com/plotly/dash2), the build is failing on **Python 3** environment.

```
File "/home/ubuntu/dash2/.tox/py34/lib/python3.4/site-packages/dash_html_components/__init__.py", line 4, in <module>
    from version import __version__
ImportError: No module named 'version'
```

Having a relative import will fix this.

```pyhon
from .version import __version__
```

I request you to bump the version and upload on PyPI after you find it suitable to merge.