### PR TITLE
Remove whitespace. Standard import 'import unittest' should be placed…

### DIFF
--- a/dash_html_components/__init__.py
+++ b/dash_html_components/__init__.py
@@ -1,6 +1,6 @@
 import os as _os
-import dash as _dash
 import sys as _sys
+import dash as _dash
 from .version import __version__
 
 _current_path = _os.path.dirname(_os.path.abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-exec (open('dash_html_components/version.py').read())
+exec(open('dash_html_components/version.py').read())
 
 setup(
     name='dash_html_components',

--- a/tests/test_dash_html_components.py
+++ b/tests/test_dash_html_components.py
@@ -1,5 +1,5 @@
-import dash_html_components
 import unittest
+import dash_html_components
 
 
 class TestDashHtmlComponents(unittest.TestCase):


### PR DESCRIPTION
… before 'import dash_html_components' (wrong-import-order). Standard import 'import sys as _sys' should be placed before 'import dash as _dash' (wrong-import-order).