### PR TITLE
Fix undefined reference to __version__ in setup.py. You can test this…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ venv/
 *.log
 .DS_Store
 lib/bundle.js
-
 lib/bundle.js.map
+.idea

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 from setuptools import setup
 
-exec(open('dash_html_components/version.py').read())
+main_ns = {}
+exec(open('dash_html_components/version.py').read(), main_ns)
 
 setup(
     name='dash_html_components',
-    version=__version__,
+    version=main_ns['__version__'],
     author='Chris Parmer',
     author_email='chris@plot.ly',
     packages=['dash_html_components'],


### PR DESCRIPTION
… fix by changing the 'version' in version.py and then running from the command line: python3 setup.py --version

Running pylint on setup.py ->  Undefined variable '__version__' (undefined-variable)