### PR TITLE
add check that dash was correctly imported and exit with helpful message if failed

### DIFF
--- a/dash_html_components/__init__.py
+++ b/dash_html_components/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function as _
 
 import os as _os
 import sys as _sys

--- a/dash_html_components/__init__.py
+++ b/dash_html_components/__init__.py
@@ -1,7 +1,16 @@
+from __future__ import print_function
+
 import os as _os
 import sys as _sys
+
 import dash as _dash
+
 from .version import __version__
+
+if not hasattr(_dash, 'development'):
+    print("Dash was not successfully imported. Make sure you don't have a file "
+          "named \n'dash.py' in your current directory.", file=_sys.stderr)
+    _sys.exit(1)
 
 _current_path = _os.path.dirname(_os.path.abspath(__file__))
 

--- a/lib/metadata.json
+++ b/lib/metadata.json
@@ -5,16 +5,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -33,176 +31,160 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "download": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates that the hyperlink is to be used for downloading a resource."
       },
       "href": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of a linked resource."
       },
       "hrefLang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the language of the linked resource."
       },
       "media": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies a hint of the media for which the linked resource was designed."
       },
       "rel": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the relationship of the target object to the link object."
       },
       "shape": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "target": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -215,16 +197,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -243,120 +223,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -369,16 +340,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -397,120 +366,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -523,16 +483,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -551,120 +509,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -677,16 +626,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -705,192 +652,174 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "alt": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Alternative text in case an image can't be displayed."
       },
       "coords": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A set of values specifying the coordinates of the hot-spot region."
       },
       "download": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates that the hyperlink is to be used for downloading a resource."
       },
       "href": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of a linked resource."
       },
       "hrefLang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the language of the linked resource."
       },
       "media": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies a hint of the media for which the linked resource was designed."
       },
       "rel": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the relationship of the target object to the link object."
       },
       "shape": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "target": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -903,16 +832,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -931,120 +858,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -1057,16 +975,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -1085,120 +1001,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -1211,16 +1118,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -1239,176 +1144,160 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "autoPlay": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The audio or video should play as soon as possible."
       },
       "controls": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the browser should show playback controls to the user."
       },
       "crossOrigin": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "How the element handles cross-origin requests"
       },
       "loop": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the media should start playing from the start when it's finished."
       },
       "muted": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the audio will be initially silenced on page load."
       },
       "preload": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the whole resource, parts of it or nothing should be preloaded."
       },
       "src": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of the embeddable content."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -1421,16 +1310,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -1449,120 +1336,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -1575,16 +1453,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -1603,136 +1479,125 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "href": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of a linked resource."
       },
       "target": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -1745,16 +1610,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -1773,120 +1636,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -1899,16 +1753,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -1927,120 +1779,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -2053,16 +1896,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -2081,120 +1922,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -2207,16 +2039,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -2235,120 +2065,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -2361,16 +2182,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -2389,120 +2208,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -2515,16 +2325,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -2543,128 +2351,118 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "cite": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Contains a URI which points to the source of the quote or change."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -2677,16 +2475,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -2705,120 +2501,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -2831,16 +2618,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -2859,176 +2644,160 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "autoFocus": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The element should be automatically focused after the page loaded."
       },
       "disabled": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the user can interact with the element."
       },
       "form": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the form that is the owner of the element."
       },
       "formAction": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the action of the element, overriding the action defined in the <form>."
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "type": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the type of the element."
       },
       "value": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a default value which will be displayed in the element on page load."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -3041,16 +2810,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -3069,136 +2836,125 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "height": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead."
       },
       "width": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -3211,16 +2967,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -3239,120 +2993,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -3365,16 +3110,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -3393,120 +3136,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -3519,16 +3253,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -3547,120 +3279,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -3673,16 +3396,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -3701,120 +3422,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -3827,16 +3539,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -3855,128 +3565,118 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "span": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -3989,16 +3689,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -4017,128 +3715,118 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "span": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -4151,16 +3839,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -4179,160 +3865,146 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "checked": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element should be checked on page load."
       },
       "disabled": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the user can interact with the element."
       },
       "icon": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies a picture which represents the command."
       },
       "radioGroup": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "type": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the type of the element."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -4345,16 +4017,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -4373,120 +4043,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -4499,16 +4160,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -4527,120 +4186,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -4653,16 +4303,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -4681,120 +4329,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -4807,16 +4446,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -4835,120 +4472,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -4961,16 +4589,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -4989,136 +4615,125 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "cite": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Contains a URI which points to the source of the quote or change."
       },
       "dateTime": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the date and time associated with the element."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -5131,16 +4746,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -5159,128 +4772,118 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "open": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the details will be shown on page load."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -5293,16 +4896,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -5321,120 +4922,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -5447,16 +5039,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -5475,120 +5065,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -5601,16 +5182,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -5629,120 +5208,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -5755,16 +5325,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -5783,120 +5351,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -5909,16 +5468,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -5937,120 +5494,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -6063,16 +5611,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -6091,120 +5637,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -6217,16 +5754,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -6245,120 +5780,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -6371,16 +5897,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -6399,152 +5923,139 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "height": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead."
       },
       "src": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of the embeddable content."
       },
       "type": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the type of the element."
       },
       "width": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -6557,16 +6068,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -6585,144 +6094,132 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "disabled": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the user can interact with the element."
       },
       "form": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the form that is the owner of the element."
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -6735,16 +6232,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -6763,120 +6258,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -6889,16 +6375,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -6917,120 +6401,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -7043,16 +6518,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -7071,120 +6544,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -7197,16 +6661,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -7225,120 +6687,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -7351,16 +6804,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -7379,192 +6830,174 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accept": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "List of types the server accepts, typically a file type."
       },
       "acceptCharset": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "List of supported charsets."
       },
       "action": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URI of a program that processes the information submitted via the form."
       },
       "autoComplete": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether controls in this form can by default have their values automatically completed by the browser."
       },
       "encType": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the content type of the form date when the method is POST."
       },
       "method": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines which HTTP method to use when submitting the form. Can be GET (default) or POST."
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "noValidate": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "This attribute indicates that the form shouldn't be validated when submitted."
       },
       "target": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -7577,16 +7010,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -7605,120 +7036,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -7731,16 +7153,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -7759,120 +7179,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -7885,16 +7296,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -7913,120 +7322,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -8039,16 +7439,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -8067,120 +7465,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -8193,16 +7582,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -8221,120 +7608,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -8347,16 +7725,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -8375,120 +7751,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -8501,16 +7868,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -8529,120 +7894,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -8655,16 +8011,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -8683,120 +8037,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -8809,16 +8154,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -8837,120 +8180,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -8963,16 +8297,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -8991,120 +8323,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -9117,16 +8440,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -9145,120 +8466,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -9271,16 +8583,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -9299,120 +8609,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -9425,16 +8726,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -9453,176 +8752,160 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "height": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead."
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "sandbox": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "seamless": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "src": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of the embeddable content."
       },
       "srcDoc": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "width": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -9635,16 +8918,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -9663,184 +8944,167 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "alt": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Alternative text in case an image can't be displayed."
       },
       "crossOrigin": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "How the element handles cross-origin requests"
       },
       "height": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead."
       },
       "sizes": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "src": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of the embeddable content."
       },
       "srcSet": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "useMap": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "width": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -9853,16 +9117,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -9881,136 +9143,125 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "cite": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Contains a URI which points to the source of the quote or change."
       },
       "dateTime": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the date and time associated with the element."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -10023,16 +9274,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -10051,120 +9300,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -10177,16 +9417,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -10205,120 +9443,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -10331,16 +9560,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -10359,168 +9586,153 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "autoFocus": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The element should be automatically focused after the page loaded."
       },
       "challenge": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A challenge string that is submitted along with the public key."
       },
       "disabled": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the user can interact with the element."
       },
       "form": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the form that is the owner of the element."
       },
       "keyType": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the type of key generated."
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -10533,16 +9745,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -10561,136 +9771,125 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "htmlFor": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Describes elements which belongs to this one."
       },
       "form": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the form that is the owner of the element."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -10703,16 +9902,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -10731,120 +9928,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -10857,16 +10045,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -10885,128 +10071,118 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "value": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a default value which will be displayed in the element on page load."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -11019,16 +10195,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -11047,176 +10221,160 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "crossOrigin": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "How the element handles cross-origin requests"
       },
       "href": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of a linked resource."
       },
       "hrefLang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the language of the linked resource."
       },
       "integrity": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Security Feature that allows browsers to verify what they fetch.     MDN Link"
       },
       "media": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies a hint of the media for which the linked resource was designed."
       },
       "rel": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the relationship of the target object to the link object."
       },
       "sizes": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -11229,16 +10387,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -11257,120 +10413,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -11383,16 +10530,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -11411,120 +10556,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -11537,16 +10673,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -11565,128 +10699,118 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -11699,16 +10823,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -11727,120 +10849,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -11853,16 +10966,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -11881,128 +10992,118 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "loop": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the media should start playing from the start when it's finished."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -12015,16 +11116,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -12043,152 +11142,139 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "charSet": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Declares the character encoding of the page or script."
       },
       "content": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A value associated with http-equiv or name depending on the context."
       },
       "httpEquiv": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -12201,16 +11287,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -12229,176 +11313,160 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "form": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the form that is the owner of the element."
       },
       "high": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the lower bound of the upper range."
       },
       "low": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the upper bound of the lower range."
       },
       "max": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the maximum value allowed."
       },
       "min": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the minimum value allowed."
       },
       "optimum": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the optimal numeric value."
       },
       "value": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a default value which will be displayed in the element on page load."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -12411,16 +11479,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -12439,120 +11505,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -12565,16 +11622,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -12593,120 +11648,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -12719,16 +11765,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -12747,120 +11791,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -12873,16 +11908,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -12901,120 +11934,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -13027,16 +12051,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -13055,120 +12077,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -13181,16 +12194,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -13209,168 +12220,153 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "form": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the form that is the owner of the element."
       },
       "height": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead."
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "type": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the type of the element."
       },
       "useMap": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "width": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -13383,16 +12379,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -13411,136 +12405,125 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "reversed": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the list should be displayed in a descending order instead of a ascending."
       },
       "start": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the first number if other than 1."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -13553,16 +12536,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -13581,128 +12562,118 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "disabled": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the user can interact with the element."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -13715,16 +12686,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -13743,144 +12712,132 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "disabled": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the user can interact with the element."
       },
       "selected": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a value which will be selected on page load."
       },
       "value": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a default value which will be displayed in the element on page load."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -13893,16 +12850,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -13921,144 +12876,132 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "htmlFor": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Describes elements which belongs to this one."
       },
       "form": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the form that is the owner of the element."
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -14071,16 +13014,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -14099,120 +13040,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -14225,16 +13157,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -14253,136 +13183,125 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "value": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a default value which will be displayed in the element on page load."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -14395,16 +13314,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -14423,120 +13340,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -14549,16 +13457,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -14577,120 +13483,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -14703,16 +13600,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -14731,120 +13626,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -14857,16 +13743,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -14885,144 +13769,132 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "form": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the form that is the owner of the element."
       },
       "max": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the maximum value allowed."
       },
       "value": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a default value which will be displayed in the element on page load."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -15035,16 +13907,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -15063,128 +13933,118 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "cite": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Contains a URI which points to the source of the quote or change."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -15197,16 +14057,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -15225,120 +14083,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -15351,16 +14200,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -15379,120 +14226,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -15505,16 +14343,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -15533,120 +14369,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -15659,16 +14486,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -15687,120 +14512,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -15813,16 +14629,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -15841,120 +14655,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -15967,16 +14772,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -15995,120 +14798,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -16121,16 +14915,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -16149,176 +14941,160 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "async": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates that the script should be executed asynchronously."
       },
       "charSet": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Declares the character encoding of the page or script."
       },
       "crossOrigin": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "How the element handles cross-origin requests"
       },
       "defer": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates that the script should be executed after the page has been parsed."
       },
       "integrity": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Security Feature that allows browsers to verify what they fetch.     MDN Link"
       },
       "src": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of the embeddable content."
       },
       "type": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the type of the element."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -16331,16 +15107,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -16359,120 +15133,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -16485,16 +15250,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -16513,176 +15276,160 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "autoFocus": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The element should be automatically focused after the page loaded."
       },
       "disabled": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the user can interact with the element."
       },
       "form": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the form that is the owner of the element."
       },
       "multiple": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether multiple values can be entered in an input of the type email or file."
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "required": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether this element is required to fill out or not."
       },
       "size": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the width of the element (in pixels). If the element's type attribute is text or password then it's the number of characters."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -16695,16 +15442,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -16723,120 +15468,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -16849,16 +15585,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -16877,120 +15611,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -17003,16 +15728,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -17031,120 +15754,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -17157,16 +15871,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -17185,152 +15897,139 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "media": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies a hint of the media for which the linked resource was designed."
       },
       "sizes": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "src": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of the embeddable content."
       },
       "type": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the type of the element."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -17343,16 +16042,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -17371,120 +16068,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -17497,16 +16185,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -17525,120 +16211,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -17651,16 +16328,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -17679,120 +16354,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -17805,16 +16471,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -17833,120 +16497,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -17959,16 +16614,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -17987,120 +16640,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -18113,16 +16757,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -18141,120 +16783,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -18267,16 +16900,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -18295,120 +16926,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -18421,16 +17043,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -18449,128 +17069,118 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "summary": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -18583,16 +17193,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -18611,120 +17219,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -18737,16 +17336,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -18765,144 +17362,132 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "colSpan": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The colspan attribute defines the number of columns a cell should span."
       },
       "headers": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "IDs of the <th> elements which applies to this element."
       },
       "rowSpan": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the number of rows a table cell should span over."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -18915,16 +17500,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -18943,120 +17526,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -19069,16 +17643,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -19097,216 +17669,195 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "autoFocus": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The element should be automatically focused after the page loaded."
       },
       "cols": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the number of columns in a textarea."
       },
       "disabled": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the user can interact with the element."
       },
       "form": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the form that is the owner of the element."
       },
       "maxLength": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the maximum number of characters allowed in the element."
       },
       "minLength": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the minimum number of characters allowed in the element."
       },
       "name": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Name of the element. For example used by the server to identify the fields in form submits."
       },
       "placeholder": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Provides a hint to the user of what can be entered in the field."
       },
       "readOnly": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element can be edited."
       },
       "required": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether this element is required to fill out or not."
       },
       "rows": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the number of rows in a text area."
       },
       "wrap": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the text should be wrapped."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -19319,16 +17870,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -19347,120 +17896,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -19473,16 +18013,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -19501,152 +18039,139 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "colSpan": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The colspan attribute defines the number of columns a cell should span."
       },
       "headers": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "IDs of the <th> elements which applies to this element."
       },
       "rowSpan": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the number of rows a table cell should span over."
       },
       "scope": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -19659,16 +18184,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -19687,120 +18210,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -19813,16 +18327,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -19841,128 +18353,118 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "dateTime": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates the date and time associated with the element."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -19975,16 +18477,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -20003,120 +18503,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -20129,16 +18620,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -20157,120 +18646,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -20283,16 +18763,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -20311,160 +18789,146 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "default": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates that the track should be enabled unless the user's preferences indicate something different."
       },
       "kind": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the kind of text track."
       },
       "label": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies a user-readable title of the text track."
       },
       "src": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of the embeddable content."
       },
       "srcLang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": ""
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -20477,16 +18941,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -20505,120 +18967,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -20631,16 +19084,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -20659,120 +19110,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -20785,16 +19227,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -20813,120 +19253,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -20939,16 +19370,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -20967,200 +19396,181 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "autoPlay": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The audio or video should play as soon as possible."
       },
       "controls": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the browser should show playback controls to the user."
       },
       "crossOrigin": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "How the element handles cross-origin requests"
       },
       "height": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead."
       },
       "loop": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the media should start playing from the start when it's finished."
       },
       "muted": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the audio will be initially silenced on page load."
       },
       "poster": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A URL indicating a poster frame to show until the user plays or seeks."
       },
       "preload": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the whole resource, parts of it or nothing should be preloaded."
       },
       "src": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The URL of the embeddable content."
       },
       "width": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead."
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -21173,16 +19583,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -21201,120 +19609,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""
@@ -21327,16 +19726,14 @@
     "props": {
       "id": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "children": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.node"
+          "name": "node"
         },
         "required": false,
         "description": "The children of this component"
@@ -21355,120 +19752,111 @@
       },
       "key": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "A unique identifier for the component, used to improve\nperformance by React.js while rendering components\nSee https://reactjs.org/docs/lists-and-keys.html for more info"
       },
       "accessKey": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Often used with CSS to style elements with common properties."
       },
       "contentEditable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether the element's content is editable."
       },
       "contextMenu": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
       },
       "dir": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
       },
       "draggable": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines whether the element can be dragged."
       },
       "hidden": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
       },
       "lang": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Defines the language used in the element."
       },
       "spellCheck": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Indicates whether spell checking is allowed for the element."
       },
       "style": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.object"
+          "name": "object"
         },
         "required": false,
         "description": "Defines CSS styles which will override styles previously set."
       },
       "tabIndex": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Overrides the browser's default tab order and follows the one specified instead."
       },
       "title": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.string"
+          "name": "string"
         },
         "required": false,
         "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "fireEvent": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.func"
+          "name": "func"
         },
         "required": false,
         "description": "A callback for firing events to dash."
       },
       "dashEvents": {
         "type": {
-          "name": "custom",
-          "raw": "PropTypes.oneOf(['click'])"
+          "name": "enum",
+          "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            }
+          ]
         },
         "required": false,
         "description": ""

--- a/tests/test_dash_import.py
+++ b/tests/test_dash_import.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+
+
+class TestDashImport(unittest.TestCase):
+    def setUp(self):
+        with open('dash.py', 'w') as f:
+            pass        
+        
+    def tearDown(self):
+        try:
+            os.remove('dash.py')
+            os.remove('dash.pyc')
+        except OSError:
+            pass
+        
+    def test_dash_import(self):
+        """Test that program exits if the wrong dash module was imported"""
+        
+        with self.assertRaises(SystemExit) as cm:
+            import dash_html_components
+
+        self.assertEqual(cm.exception.code, 1)

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,5 @@ commands =
     python --version
     python -m unittest tests.test_dash_html_components
     python -m unittest tests.test_integration
+    python -m unittest tests.test_dash_import
+    


### PR DESCRIPTION
A common gotcha that people new to Dash encounter is naming their script 'dash.py' which then shadows the Dash package itself, causing unhappy times. This adds an explicit check that the `dash.development` attribute exists, which if it doesn't, it's likely this situation has happened, so a more helpful error message is printed to standard error, and the script exits. 

This catches at least some of the times that this error occurs. If we also change the import order for example code from the Dash User guide to make `from dash.dependencies import Input, State, Output` come after after the import of `dash_core_components` this will then catch a lot more. 

(This mirrors the same check added in plotly/dash-core-components#177)
