### PR TITLE
Fix MANIFEST.in to include license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include dash_html_components/bundle.js
 include dash_html_components/bundle.js.map
 include dash_html_components/metadata.json
 include README.md
-include LICENSE.md
+include LICENSE.txt


### PR DESCRIPTION
Incorrect file name in the `MANIFEST.in`. Changes so that it will be included in the source distribution