### PR TITLE
 Generate Dash components at buildtime rather than runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.12.0] - 2018-06-01
+### Changed
+- `dash_html_components/__init__.py` now imports from python class files rather than generating classes at runtime,
+adding support for IDE autocomplete ect.
+
 ## [0.11.0] - 2018-06-01
 ### Added
 - A `n_clicks_timestamp` property was added to all of the components. This property represents the date that the element was clicked on and can be used to determine _which element was clicked on_ in callbacks with multiple elements. This is considered a stop-gap solution: ultimately we'll want a solution that works for _all_ properties across all components, not just the `n_clicks` property. https://github.com/plotly/dash-html-components/pull/45

--- a/dash_html_components/A.py
+++ b/dash_html_components/A.py
@@ -1,0 +1,82 @@
+from dash.development.base_component import Component
+
+
+class A(Component):
+    """A A component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- download (string; optional): Indicates that the hyperlink is to be used for downloading a resource.
+- href (string; optional): The URL of a linked resource.
+- hrefLang (string; optional): Specifies the language of the linked resource.
+- media (string; optional): Specifies a hint of the media for which the linked resource was designed.
+- rel (string; optional): Specifies the relationship of the target object to the link object.
+- shape (string; optional)
+- target (string; optional)
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'download', 'href', 'hrefLang', 'media', 'rel', 'shape', 'target', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'A'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'download', 'href', 'hrefLang', 'media', 'rel', 'shape', 'target', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(A, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('A(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'A(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Abbr.py
+++ b/dash_html_components/Abbr.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Abbr(Component):
+    """A Abbr component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Abbr'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Abbr, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Abbr(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Abbr(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Acronym.py
+++ b/dash_html_components/Acronym.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Acronym(Component):
+    """A Acronym component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Acronym'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Acronym, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Acronym(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Acronym(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Address.py
+++ b/dash_html_components/Address.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Address(Component):
+    """A Address component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Address'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Address, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Address(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Address(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Area.py
+++ b/dash_html_components/Area.py
@@ -1,0 +1,84 @@
+from dash.development.base_component import Component
+
+
+class Area(Component):
+    """A Area component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- alt (string; optional): Alternative text in case an image can't be displayed.
+- coords (string; optional): A set of values specifying the coordinates of the hot-spot region.
+- download (string; optional): Indicates that the hyperlink is to be used for downloading a resource.
+- href (string; optional): The URL of a linked resource.
+- hrefLang (string; optional): Specifies the language of the linked resource.
+- media (string; optional): Specifies a hint of the media for which the linked resource was designed.
+- rel (string; optional): Specifies the relationship of the target object to the link object.
+- shape (string; optional)
+- target (string; optional)
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'alt', 'coords', 'download', 'href', 'hrefLang', 'media', 'rel', 'shape', 'target', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Area'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'alt', 'coords', 'download', 'href', 'hrefLang', 'media', 'rel', 'shape', 'target', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Area, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Area(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Area(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Article.py
+++ b/dash_html_components/Article.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Article(Component):
+    """A Article component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Article'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Article, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Article(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Article(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Aside.py
+++ b/dash_html_components/Aside.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Aside(Component):
+    """A Aside component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Aside'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Aside, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Aside(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Aside(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Audio.py
+++ b/dash_html_components/Audio.py
@@ -1,0 +1,82 @@
+from dash.development.base_component import Component
+
+
+class Audio(Component):
+    """A Audio component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- autoPlay (string; optional): The audio or video should play as soon as possible.
+- controls (string; optional): Indicates whether the browser should show playback controls to the user.
+- crossOrigin (string; optional): How the element handles cross-origin requests
+- loop (string; optional): Indicates whether the media should start playing from the start when it's finished.
+- muted (string; optional): Indicates whether the audio will be initially silenced on page load.
+- preload (string; optional): Indicates whether the whole resource, parts of it or nothing should be preloaded.
+- src (string; optional): The URL of the embeddable content.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoPlay', 'controls', 'crossOrigin', 'loop', 'muted', 'preload', 'src', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Audio'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoPlay', 'controls', 'crossOrigin', 'loop', 'muted', 'preload', 'src', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Audio, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Audio(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Audio(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/B.py
+++ b/dash_html_components/B.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class B(Component):
+    """A B component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'B'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(B, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('B(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'B(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Base.py
+++ b/dash_html_components/Base.py
@@ -1,0 +1,77 @@
+from dash.development.base_component import Component
+
+
+class Base(Component):
+    """A Base component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- href (string; optional): The URL of a linked resource.
+- target (string; optional)
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'href', 'target', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Base'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'href', 'target', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Base, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Base(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Base(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Basefont.py
+++ b/dash_html_components/Basefont.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Basefont(Component):
+    """A Basefont component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Basefont'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Basefont, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Basefont(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Basefont(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Bdi.py
+++ b/dash_html_components/Bdi.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Bdi(Component):
+    """A Bdi component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Bdi'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Bdi, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Bdi(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Bdi(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Bdo.py
+++ b/dash_html_components/Bdo.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Bdo(Component):
+    """A Bdo component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Bdo'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Bdo, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Bdo(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Bdo(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Big.py
+++ b/dash_html_components/Big.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Big(Component):
+    """A Big component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Big'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Big, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Big(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Big(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Blink.py
+++ b/dash_html_components/Blink.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Blink(Component):
+    """A Blink component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Blink'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Blink, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Blink(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Blink(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Blockquote.py
+++ b/dash_html_components/Blockquote.py
@@ -1,0 +1,76 @@
+from dash.development.base_component import Component
+
+
+class Blockquote(Component):
+    """A Blockquote component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- cite (string; optional): Contains a URI which points to the source of the quote or change.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'cite', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Blockquote'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'cite', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Blockquote, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Blockquote(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Blockquote(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Br.py
+++ b/dash_html_components/Br.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Br(Component):
+    """A Br component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Br'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Br, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Br(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Br(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Button.py
+++ b/dash_html_components/Button.py
@@ -1,0 +1,82 @@
+from dash.development.base_component import Component
+
+
+class Button(Component):
+    """A Button component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- autoFocus (string; optional): The element should be automatically focused after the page loaded.
+- disabled (string; optional): Indicates whether the user can interact with the element.
+- form (string; optional): Indicates the form that is the owner of the element.
+- formAction (string; optional): Indicates the action of the element, overriding the action defined in the <form>.
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- type (string; optional): Defines the type of the element.
+- value (string; optional): Defines a default value which will be displayed in the element on page load.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoFocus', 'disabled', 'form', 'formAction', 'name', 'type', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Button'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoFocus', 'disabled', 'form', 'formAction', 'name', 'type', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Button, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Button(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Button(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Canvas.py
+++ b/dash_html_components/Canvas.py
@@ -1,0 +1,77 @@
+from dash.development.base_component import Component
+
+
+class Canvas(Component):
+    """A Canvas component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- height (string; optional): Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead.
+- width (string; optional): For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'height', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Canvas'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'height', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Canvas, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Canvas(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Canvas(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Caption.py
+++ b/dash_html_components/Caption.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Caption(Component):
+    """A Caption component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Caption'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Caption, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Caption(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Caption(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Center.py
+++ b/dash_html_components/Center.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Center(Component):
+    """A Center component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Center'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Center, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Center(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Center(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Cite.py
+++ b/dash_html_components/Cite.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Cite(Component):
+    """A Cite component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Cite'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Cite, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Cite(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Cite(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Code.py
+++ b/dash_html_components/Code.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Code(Component):
+    """A Code component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Code'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Code, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Code(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Code(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Col.py
+++ b/dash_html_components/Col.py
@@ -1,0 +1,76 @@
+from dash.development.base_component import Component
+
+
+class Col(Component):
+    """A Col component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- span (string; optional)
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'span', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Col'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'span', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Col, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Col(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Col(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Colgroup.py
+++ b/dash_html_components/Colgroup.py
@@ -1,0 +1,76 @@
+from dash.development.base_component import Component
+
+
+class Colgroup(Component):
+    """A Colgroup component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- span (string; optional)
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'span', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Colgroup'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'span', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Colgroup, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Colgroup(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Colgroup(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Command.py
+++ b/dash_html_components/Command.py
@@ -1,0 +1,80 @@
+from dash.development.base_component import Component
+
+
+class Command(Component):
+    """A Command component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- checked (string; optional): Indicates whether the element should be checked on page load.
+- disabled (string; optional): Indicates whether the user can interact with the element.
+- icon (string; optional): Specifies a picture which represents the command.
+- radioGroup (string; optional)
+- type (string; optional): Defines the type of the element.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'checked', 'disabled', 'icon', 'radioGroup', 'type', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Command'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'checked', 'disabled', 'icon', 'radioGroup', 'type', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Command, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Command(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Command(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Content.py
+++ b/dash_html_components/Content.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Content(Component):
+    """A Content component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Content'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Content, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Content(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Content(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Data.py
+++ b/dash_html_components/Data.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Data(Component):
+    """A Data component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Data'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Data, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Data(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Data(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Datalist.py
+++ b/dash_html_components/Datalist.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Datalist(Component):
+    """A Datalist component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Datalist'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Datalist, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Datalist(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Datalist(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Dd.py
+++ b/dash_html_components/Dd.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Dd(Component):
+    """A Dd component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Dd'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Dd, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Dd(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Dd(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Del.py
+++ b/dash_html_components/Del.py
@@ -1,0 +1,77 @@
+from dash.development.base_component import Component
+
+
+class Del(Component):
+    """A Del component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- cite (string; optional): Contains a URI which points to the source of the quote or change.
+- dateTime (string; optional): Indicates the date and time associated with the element.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'cite', 'dateTime', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Del'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'cite', 'dateTime', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Del, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Del(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Del(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Details.py
+++ b/dash_html_components/Details.py
@@ -1,0 +1,76 @@
+from dash.development.base_component import Component
+
+
+class Details(Component):
+    """A Details component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- open (string; optional): Indicates whether the details will be shown on page load.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'open', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Details'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'open', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Details, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Details(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Details(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Dfn.py
+++ b/dash_html_components/Dfn.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Dfn(Component):
+    """A Dfn component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Dfn'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Dfn, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Dfn(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Dfn(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Dialog.py
+++ b/dash_html_components/Dialog.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Dialog(Component):
+    """A Dialog component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Dialog'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Dialog, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Dialog(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Dialog(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Div.py
+++ b/dash_html_components/Div.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Div(Component):
+    """A Div component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Div'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Div, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Div(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Div(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Dl.py
+++ b/dash_html_components/Dl.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Dl(Component):
+    """A Dl component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Dl'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Dl, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Dl(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Dl(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Dt.py
+++ b/dash_html_components/Dt.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Dt(Component):
+    """A Dt component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Dt'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Dt, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Dt(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Dt(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Element.py
+++ b/dash_html_components/Element.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Element(Component):
+    """A Element component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Element'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Element, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Element(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Element(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Em.py
+++ b/dash_html_components/Em.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Em(Component):
+    """A Em component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Em'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Em, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Em(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Em(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Embed.py
+++ b/dash_html_components/Embed.py
@@ -1,0 +1,79 @@
+from dash.development.base_component import Component
+
+
+class Embed(Component):
+    """A Embed component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- height (string; optional): Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead.
+- src (string; optional): The URL of the embeddable content.
+- type (string; optional): Defines the type of the element.
+- width (string; optional): For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'height', 'src', 'type', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Embed'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'height', 'src', 'type', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Embed, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Embed(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Embed(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Fieldset.py
+++ b/dash_html_components/Fieldset.py
@@ -1,0 +1,78 @@
+from dash.development.base_component import Component
+
+
+class Fieldset(Component):
+    """A Fieldset component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- disabled (string; optional): Indicates whether the user can interact with the element.
+- form (string; optional): Indicates the form that is the owner of the element.
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'disabled', 'form', 'name', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Fieldset'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'disabled', 'form', 'name', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Fieldset, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Fieldset(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Fieldset(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Figcaption.py
+++ b/dash_html_components/Figcaption.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Figcaption(Component):
+    """A Figcaption component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Figcaption'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Figcaption, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Figcaption(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Figcaption(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Figure.py
+++ b/dash_html_components/Figure.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Figure(Component):
+    """A Figure component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Figure'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Figure, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Figure(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Figure(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Font.py
+++ b/dash_html_components/Font.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Font(Component):
+    """A Font component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Font'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Font, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Font(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Font(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Footer.py
+++ b/dash_html_components/Footer.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Footer(Component):
+    """A Footer component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Footer'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Footer, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Footer(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Footer(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Form.py
+++ b/dash_html_components/Form.py
@@ -1,0 +1,84 @@
+from dash.development.base_component import Component
+
+
+class Form(Component):
+    """A Form component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accept (string; optional): List of types the server accepts, typically a file type.
+- acceptCharset (string; optional): List of supported charsets.
+- action (string; optional): The URI of a program that processes the information submitted via the form.
+- autoComplete (string; optional): Indicates whether controls in this form can by default have their values automatically completed by the browser.
+- encType (string; optional): Defines the content type of the form date when the method is POST.
+- method (string; optional): Defines which HTTP method to use when submitting the form. Can be GET (default) or POST.
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- noValidate (string; optional): This attribute indicates that the form shouldn't be validated when submitted.
+- target (string; optional)
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accept', 'acceptCharset', 'action', 'autoComplete', 'encType', 'method', 'name', 'noValidate', 'target', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Form'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accept', 'acceptCharset', 'action', 'autoComplete', 'encType', 'method', 'name', 'noValidate', 'target', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Form, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Form(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Form(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Frame.py
+++ b/dash_html_components/Frame.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Frame(Component):
+    """A Frame component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Frame'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Frame, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Frame(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Frame(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Frameset.py
+++ b/dash_html_components/Frameset.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Frameset(Component):
+    """A Frameset component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Frameset'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Frameset, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Frameset(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Frameset(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/H1.py
+++ b/dash_html_components/H1.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class H1(Component):
+    """A H1 component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'H1'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(H1, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('H1(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'H1(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/H2.py
+++ b/dash_html_components/H2.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class H2(Component):
+    """A H2 component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'H2'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(H2, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('H2(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'H2(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/H3.py
+++ b/dash_html_components/H3.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class H3(Component):
+    """A H3 component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'H3'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(H3, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('H3(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'H3(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/H4.py
+++ b/dash_html_components/H4.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class H4(Component):
+    """A H4 component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'H4'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(H4, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('H4(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'H4(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/H5.py
+++ b/dash_html_components/H5.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class H5(Component):
+    """A H5 component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'H5'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(H5, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('H5(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'H5(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/H6.py
+++ b/dash_html_components/H6.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class H6(Component):
+    """A H6 component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'H6'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(H6, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('H6(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'H6(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Header.py
+++ b/dash_html_components/Header.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Header(Component):
+    """A Header component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Header'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Header, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Header(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Header(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Hgroup.py
+++ b/dash_html_components/Hgroup.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Hgroup(Component):
+    """A Hgroup component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Hgroup'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Hgroup, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Hgroup(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Hgroup(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Hr.py
+++ b/dash_html_components/Hr.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Hr(Component):
+    """A Hr component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Hr'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Hr, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Hr(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Hr(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/I.py
+++ b/dash_html_components/I.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class I(Component):
+    """A I component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'I'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(I, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('I(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'I(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Iframe.py
+++ b/dash_html_components/Iframe.py
@@ -1,0 +1,81 @@
+from dash.development.base_component import Component
+
+
+class Iframe(Component):
+    """A Iframe component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- height (string; optional): Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead.
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- sandbox (string; optional): Stops a document loaded in an iframe from using certain features (such as submitting forms or opening new windows).
+- src (string; optional): The URL of the embeddable content.
+- srcDoc (string; optional)
+- width (string; optional): For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'height', 'name', 'sandbox', 'src', 'srcDoc', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Iframe'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'height', 'name', 'sandbox', 'src', 'srcDoc', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Iframe, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Iframe(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Iframe(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Img.py
+++ b/dash_html_components/Img.py
@@ -1,0 +1,83 @@
+from dash.development.base_component import Component
+
+
+class Img(Component):
+    """A Img component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- alt (string; optional): Alternative text in case an image can't be displayed.
+- crossOrigin (string; optional): How the element handles cross-origin requests
+- height (string; optional): Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead.
+- sizes (string; optional)
+- src (string; optional): The URL of the embeddable content.
+- srcSet (string; optional)
+- useMap (string; optional)
+- width (string; optional): For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'alt', 'crossOrigin', 'height', 'sizes', 'src', 'srcSet', 'useMap', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Img'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'alt', 'crossOrigin', 'height', 'sizes', 'src', 'srcSet', 'useMap', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Img, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Img(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Img(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Ins.py
+++ b/dash_html_components/Ins.py
@@ -1,0 +1,77 @@
+from dash.development.base_component import Component
+
+
+class Ins(Component):
+    """A Ins component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- cite (string; optional): Contains a URI which points to the source of the quote or change.
+- dateTime (string; optional): Indicates the date and time associated with the element.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'cite', 'dateTime', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Ins'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'cite', 'dateTime', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Ins, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Ins(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Ins(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Isindex.py
+++ b/dash_html_components/Isindex.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Isindex(Component):
+    """A Isindex component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Isindex'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Isindex, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Isindex(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Isindex(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Kbd.py
+++ b/dash_html_components/Kbd.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Kbd(Component):
+    """A Kbd component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Kbd'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Kbd, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Kbd(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Kbd(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Keygen.py
+++ b/dash_html_components/Keygen.py
@@ -1,0 +1,81 @@
+from dash.development.base_component import Component
+
+
+class Keygen(Component):
+    """A Keygen component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- autoFocus (string; optional): The element should be automatically focused after the page loaded.
+- challenge (string; optional): A challenge string that is submitted along with the public key.
+- disabled (string; optional): Indicates whether the user can interact with the element.
+- form (string; optional): Indicates the form that is the owner of the element.
+- keyType (string; optional): Specifies the type of key generated.
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoFocus', 'challenge', 'disabled', 'form', 'keyType', 'name', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Keygen'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoFocus', 'challenge', 'disabled', 'form', 'keyType', 'name', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Keygen, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Keygen(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Keygen(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Label.py
+++ b/dash_html_components/Label.py
@@ -1,0 +1,77 @@
+from dash.development.base_component import Component
+
+
+class Label(Component):
+    """A Label component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- htmlFor (string; optional): Describes elements which belongs to this one.
+- form (string; optional): Indicates the form that is the owner of the element.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'htmlFor', 'form', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Label'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'htmlFor', 'form', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Label, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Label(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Label(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Legend.py
+++ b/dash_html_components/Legend.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Legend(Component):
+    """A Legend component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Legend'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Legend, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Legend(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Legend(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Li.py
+++ b/dash_html_components/Li.py
@@ -1,0 +1,76 @@
+from dash.development.base_component import Component
+
+
+class Li(Component):
+    """A Li component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- value (string; optional): Defines a default value which will be displayed in the element on page load.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Li'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Li, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Li(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Li(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Link.py
+++ b/dash_html_components/Link.py
@@ -1,0 +1,82 @@
+from dash.development.base_component import Component
+
+
+class Link(Component):
+    """A Link component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- crossOrigin (string; optional): How the element handles cross-origin requests
+- href (string; optional): The URL of a linked resource.
+- hrefLang (string; optional): Specifies the language of the linked resource.
+- integrity (string; optional): Security Feature that allows browsers to verify what they fetch.     MDN Link
+- media (string; optional): Specifies a hint of the media for which the linked resource was designed.
+- rel (string; optional): Specifies the relationship of the target object to the link object.
+- sizes (string; optional)
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'crossOrigin', 'href', 'hrefLang', 'integrity', 'media', 'rel', 'sizes', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Link'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'crossOrigin', 'href', 'hrefLang', 'integrity', 'media', 'rel', 'sizes', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Link, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Link(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Link(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Listing.py
+++ b/dash_html_components/Listing.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Listing(Component):
+    """A Listing component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Listing'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Listing, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Listing(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Listing(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Main.py
+++ b/dash_html_components/Main.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Main(Component):
+    """A Main component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Main'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Main, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Main(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Main(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/MapEl.py
+++ b/dash_html_components/MapEl.py
@@ -1,0 +1,76 @@
+from dash.development.base_component import Component
+
+
+class MapEl(Component):
+    """A MapEl component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'name', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'MapEl'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'name', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(MapEl, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('MapEl(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'MapEl(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Mark.py
+++ b/dash_html_components/Mark.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Mark(Component):
+    """A Mark component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Mark'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Mark, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Mark(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Mark(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Marquee.py
+++ b/dash_html_components/Marquee.py
@@ -1,0 +1,76 @@
+from dash.development.base_component import Component
+
+
+class Marquee(Component):
+    """A Marquee component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- loop (string; optional): Indicates whether the media should start playing from the start when it's finished.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'loop', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Marquee'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'loop', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Marquee, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Marquee(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Marquee(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Meta.py
+++ b/dash_html_components/Meta.py
@@ -1,0 +1,79 @@
+from dash.development.base_component import Component
+
+
+class Meta(Component):
+    """A Meta component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- charSet (string; optional): Declares the character encoding of the page or script.
+- content (string; optional): A value associated with http-equiv or name depending on the context.
+- httpEquiv (string; optional)
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'charSet', 'content', 'httpEquiv', 'name', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Meta'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'charSet', 'content', 'httpEquiv', 'name', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Meta, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Meta(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Meta(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Meter.py
+++ b/dash_html_components/Meter.py
@@ -1,0 +1,82 @@
+from dash.development.base_component import Component
+
+
+class Meter(Component):
+    """A Meter component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- form (string; optional): Indicates the form that is the owner of the element.
+- high (string; optional): Indicates the lower bound of the upper range.
+- low (string; optional): Indicates the upper bound of the lower range.
+- max (string; optional): Indicates the maximum value allowed.
+- min (string; optional): Indicates the minimum value allowed.
+- optimum (string; optional): Indicates the optimal numeric value.
+- value (string; optional): Defines a default value which will be displayed in the element on page load.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'form', 'high', 'low', 'max', 'min', 'optimum', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Meter'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'form', 'high', 'low', 'max', 'min', 'optimum', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Meter, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Meter(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Meter(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Multicol.py
+++ b/dash_html_components/Multicol.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Multicol(Component):
+    """A Multicol component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Multicol'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Multicol, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Multicol(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Multicol(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Nav.py
+++ b/dash_html_components/Nav.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Nav(Component):
+    """A Nav component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Nav'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Nav, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Nav(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Nav(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Nextid.py
+++ b/dash_html_components/Nextid.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Nextid(Component):
+    """A Nextid component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Nextid'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Nextid, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Nextid(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Nextid(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Nobr.py
+++ b/dash_html_components/Nobr.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Nobr(Component):
+    """A Nobr component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Nobr'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Nobr, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Nobr(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Nobr(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Noscript.py
+++ b/dash_html_components/Noscript.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Noscript(Component):
+    """A Noscript component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Noscript'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Noscript, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Noscript(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Noscript(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/ObjectEl.py
+++ b/dash_html_components/ObjectEl.py
@@ -1,0 +1,81 @@
+from dash.development.base_component import Component
+
+
+class ObjectEl(Component):
+    """A ObjectEl component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- form (string; optional): Indicates the form that is the owner of the element.
+- height (string; optional): Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead.
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- type (string; optional): Defines the type of the element.
+- useMap (string; optional)
+- width (string; optional): For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'form', 'height', 'name', 'type', 'useMap', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'ObjectEl'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'form', 'height', 'name', 'type', 'useMap', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(ObjectEl, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('ObjectEl(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'ObjectEl(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Ol.py
+++ b/dash_html_components/Ol.py
@@ -1,0 +1,77 @@
+from dash.development.base_component import Component
+
+
+class Ol(Component):
+    """A Ol component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- reversed (string; optional): Indicates whether the list should be displayed in a descending order instead of a ascending.
+- start (string; optional): Defines the first number if other than 1.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'reversed', 'start', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Ol'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'reversed', 'start', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Ol, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Ol(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Ol(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Optgroup.py
+++ b/dash_html_components/Optgroup.py
@@ -1,0 +1,76 @@
+from dash.development.base_component import Component
+
+
+class Optgroup(Component):
+    """A Optgroup component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- disabled (string; optional): Indicates whether the user can interact with the element.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'disabled', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Optgroup'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'disabled', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Optgroup, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Optgroup(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Optgroup(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Option.py
+++ b/dash_html_components/Option.py
@@ -1,0 +1,78 @@
+from dash.development.base_component import Component
+
+
+class Option(Component):
+    """A Option component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- disabled (string; optional): Indicates whether the user can interact with the element.
+- selected (string; optional): Defines a value which will be selected on page load.
+- value (string; optional): Defines a default value which will be displayed in the element on page load.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'disabled', 'selected', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Option'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'disabled', 'selected', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Option, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Option(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Option(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Output.py
+++ b/dash_html_components/Output.py
@@ -1,0 +1,78 @@
+from dash.development.base_component import Component
+
+
+class Output(Component):
+    """A Output component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- htmlFor (string; optional): Describes elements which belongs to this one.
+- form (string; optional): Indicates the form that is the owner of the element.
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'htmlFor', 'form', 'name', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Output'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'htmlFor', 'form', 'name', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Output, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Output(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Output(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/P.py
+++ b/dash_html_components/P.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class P(Component):
+    """A P component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'P'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(P, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('P(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'P(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Param.py
+++ b/dash_html_components/Param.py
@@ -1,0 +1,77 @@
+from dash.development.base_component import Component
+
+
+class Param(Component):
+    """A Param component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- value (string; optional): Defines a default value which will be displayed in the element on page load.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'name', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Param'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'name', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Param, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Param(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Param(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Picture.py
+++ b/dash_html_components/Picture.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Picture(Component):
+    """A Picture component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Picture'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Picture, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Picture(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Picture(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Plaintext.py
+++ b/dash_html_components/Plaintext.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Plaintext(Component):
+    """A Plaintext component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Plaintext'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Plaintext, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Plaintext(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Plaintext(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Pre.py
+++ b/dash_html_components/Pre.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Pre(Component):
+    """A Pre component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Pre'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Pre, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Pre(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Pre(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Progress.py
+++ b/dash_html_components/Progress.py
@@ -1,0 +1,78 @@
+from dash.development.base_component import Component
+
+
+class Progress(Component):
+    """A Progress component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- form (string; optional): Indicates the form that is the owner of the element.
+- max (string; optional): Indicates the maximum value allowed.
+- value (string; optional): Defines a default value which will be displayed in the element on page load.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'form', 'max', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Progress'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'form', 'max', 'value', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Progress, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Progress(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Progress(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Q.py
+++ b/dash_html_components/Q.py
@@ -1,0 +1,76 @@
+from dash.development.base_component import Component
+
+
+class Q(Component):
+    """A Q component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- cite (string; optional): Contains a URI which points to the source of the quote or change.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'cite', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Q'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'cite', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Q, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Q(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Q(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Rp.py
+++ b/dash_html_components/Rp.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Rp(Component):
+    """A Rp component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Rp'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Rp, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Rp(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Rp(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Rt.py
+++ b/dash_html_components/Rt.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Rt(Component):
+    """A Rt component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Rt'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Rt, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Rt(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Rt(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Rtc.py
+++ b/dash_html_components/Rtc.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Rtc(Component):
+    """A Rtc component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Rtc'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Rtc, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Rtc(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Rtc(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Ruby.py
+++ b/dash_html_components/Ruby.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Ruby(Component):
+    """A Ruby component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Ruby'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Ruby, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Ruby(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Ruby(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/S.py
+++ b/dash_html_components/S.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class S(Component):
+    """A S component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'S'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(S, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('S(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'S(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Samp.py
+++ b/dash_html_components/Samp.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Samp(Component):
+    """A Samp component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Samp'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Samp, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Samp(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Samp(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Script.py
+++ b/dash_html_components/Script.py
@@ -1,0 +1,82 @@
+from dash.development.base_component import Component
+
+
+class Script(Component):
+    """A Script component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- async (string; optional): Indicates that the script should be executed asynchronously.
+- charSet (string; optional): Declares the character encoding of the page or script.
+- crossOrigin (string; optional): How the element handles cross-origin requests
+- defer (string; optional): Indicates that the script should be executed after the page has been parsed.
+- integrity (string; optional): Security Feature that allows browsers to verify what they fetch.     MDN Link
+- src (string; optional): The URL of the embeddable content.
+- type (string; optional): Defines the type of the element.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'async', 'charSet', 'crossOrigin', 'defer', 'integrity', 'src', 'type', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Script'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'async', 'charSet', 'crossOrigin', 'defer', 'integrity', 'src', 'type', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Script, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Script(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Script(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Section.py
+++ b/dash_html_components/Section.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Section(Component):
+    """A Section component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Section'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Section, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Section(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Section(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Select.py
+++ b/dash_html_components/Select.py
@@ -1,0 +1,82 @@
+from dash.development.base_component import Component
+
+
+class Select(Component):
+    """A Select component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- autoFocus (string; optional): The element should be automatically focused after the page loaded.
+- disabled (string; optional): Indicates whether the user can interact with the element.
+- form (string; optional): Indicates the form that is the owner of the element.
+- multiple (string; optional): Indicates whether multiple values can be entered in an input of the type email or file.
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- required (string; optional): Indicates whether this element is required to fill out or not.
+- size (string; optional): Defines the width of the element (in pixels). If the element's type attribute is text or password then it's the number of characters.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoFocus', 'disabled', 'form', 'multiple', 'name', 'required', 'size', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Select'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoFocus', 'disabled', 'form', 'multiple', 'name', 'required', 'size', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Select, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Select(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Select(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Shadow.py
+++ b/dash_html_components/Shadow.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Shadow(Component):
+    """A Shadow component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Shadow'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Shadow, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Shadow(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Shadow(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Slot.py
+++ b/dash_html_components/Slot.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Slot(Component):
+    """A Slot component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Slot'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Slot, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Slot(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Slot(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Small.py
+++ b/dash_html_components/Small.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Small(Component):
+    """A Small component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Small'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Small, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Small(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Small(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Source.py
+++ b/dash_html_components/Source.py
@@ -1,0 +1,79 @@
+from dash.development.base_component import Component
+
+
+class Source(Component):
+    """A Source component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- media (string; optional): Specifies a hint of the media for which the linked resource was designed.
+- sizes (string; optional)
+- src (string; optional): The URL of the embeddable content.
+- type (string; optional): Defines the type of the element.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'media', 'sizes', 'src', 'type', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Source'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'media', 'sizes', 'src', 'type', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Source, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Source(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Source(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Spacer.py
+++ b/dash_html_components/Spacer.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Spacer(Component):
+    """A Spacer component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Spacer'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Spacer, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Spacer(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Spacer(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Span.py
+++ b/dash_html_components/Span.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Span(Component):
+    """A Span component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Span'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Span, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Span(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Span(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Strike.py
+++ b/dash_html_components/Strike.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Strike(Component):
+    """A Strike component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Strike'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Strike, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Strike(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Strike(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Strong.py
+++ b/dash_html_components/Strong.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Strong(Component):
+    """A Strong component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Strong'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Strong, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Strong(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Strong(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Sub.py
+++ b/dash_html_components/Sub.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Sub(Component):
+    """A Sub component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Sub'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Sub, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Sub(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Sub(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Summary.py
+++ b/dash_html_components/Summary.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Summary(Component):
+    """A Summary component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Summary'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Summary, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Summary(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Summary(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Sup.py
+++ b/dash_html_components/Sup.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Sup(Component):
+    """A Sup component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Sup'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Sup, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Sup(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Sup(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Table.py
+++ b/dash_html_components/Table.py
@@ -1,0 +1,76 @@
+from dash.development.base_component import Component
+
+
+class Table(Component):
+    """A Table component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- summary (string; optional)
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'summary', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Table'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'summary', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Table, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Table(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Table(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Tbody.py
+++ b/dash_html_components/Tbody.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Tbody(Component):
+    """A Tbody component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Tbody'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Tbody, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Tbody(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Tbody(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Td.py
+++ b/dash_html_components/Td.py
@@ -1,0 +1,78 @@
+from dash.development.base_component import Component
+
+
+class Td(Component):
+    """A Td component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- colSpan (string; optional): The colspan attribute defines the number of columns a cell should span.
+- headers (string; optional): IDs of the <th> elements which applies to this element.
+- rowSpan (string; optional): Defines the number of rows a table cell should span over.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'colSpan', 'headers', 'rowSpan', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Td'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'colSpan', 'headers', 'rowSpan', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Td, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Td(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Td(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Template.py
+++ b/dash_html_components/Template.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Template(Component):
+    """A Template component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Template'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Template, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Template(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Template(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Textarea.py
+++ b/dash_html_components/Textarea.py
@@ -1,0 +1,88 @@
+from dash.development.base_component import Component
+
+
+class Textarea(Component):
+    """A Textarea component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- autoComplete (string; optional): Indicates whether controls in this form can by default have their values automatically completed by the browser.
+- autoFocus (string; optional): The element should be automatically focused after the page loaded.
+- cols (string; optional): Defines the number of columns in a textarea.
+- disabled (string; optional): Indicates whether the user can interact with the element.
+- form (string; optional): Indicates the form that is the owner of the element.
+- maxLength (string; optional): Defines the maximum number of characters allowed in the element.
+- minLength (string; optional): Defines the minimum number of characters allowed in the element.
+- name (string; optional): Name of the element. For example used by the server to identify the fields in form submits.
+- placeholder (string; optional): Provides a hint to the user of what can be entered in the field.
+- readOnly (string; optional): Indicates whether the element can be edited.
+- required (string; optional): Indicates whether this element is required to fill out or not.
+- rows (string; optional): Defines the number of rows in a text area.
+- wrap (string; optional): Indicates whether the text should be wrapped.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoComplete', 'autoFocus', 'cols', 'disabled', 'form', 'maxLength', 'minLength', 'name', 'placeholder', 'readOnly', 'required', 'rows', 'wrap', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Textarea'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoComplete', 'autoFocus', 'cols', 'disabled', 'form', 'maxLength', 'minLength', 'name', 'placeholder', 'readOnly', 'required', 'rows', 'wrap', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Textarea, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Textarea(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Textarea(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Tfoot.py
+++ b/dash_html_components/Tfoot.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Tfoot(Component):
+    """A Tfoot component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Tfoot'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Tfoot, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Tfoot(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Tfoot(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Th.py
+++ b/dash_html_components/Th.py
@@ -1,0 +1,79 @@
+from dash.development.base_component import Component
+
+
+class Th(Component):
+    """A Th component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- colSpan (string; optional): The colspan attribute defines the number of columns a cell should span.
+- headers (string; optional): IDs of the <th> elements which applies to this element.
+- rowSpan (string; optional): Defines the number of rows a table cell should span over.
+- scope (string; optional): Defines the cells that the header test (defined in the th element) relates to.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'colSpan', 'headers', 'rowSpan', 'scope', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Th'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'colSpan', 'headers', 'rowSpan', 'scope', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Th, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Th(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Th(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Thead.py
+++ b/dash_html_components/Thead.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Thead(Component):
+    """A Thead component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Thead'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Thead, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Thead(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Thead(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Time.py
+++ b/dash_html_components/Time.py
@@ -1,0 +1,76 @@
+from dash.development.base_component import Component
+
+
+class Time(Component):
+    """A Time component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- dateTime (string; optional): Indicates the date and time associated with the element.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'dateTime', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Time'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'dateTime', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Time, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Time(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Time(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Title.py
+++ b/dash_html_components/Title.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Title(Component):
+    """A Title component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Title'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Title, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Title(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Title(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Tr.py
+++ b/dash_html_components/Tr.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Tr(Component):
+    """A Tr component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Tr'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Tr, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Tr(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Tr(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Track.py
+++ b/dash_html_components/Track.py
@@ -1,0 +1,80 @@
+from dash.development.base_component import Component
+
+
+class Track(Component):
+    """A Track component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- default (string; optional): Indicates that the track should be enabled unless the user's preferences indicate something different.
+- kind (string; optional): Specifies the kind of text track.
+- label (string; optional): Specifies a user-readable title of the text track.
+- src (string; optional): The URL of the embeddable content.
+- srcLang (string; optional)
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'default', 'kind', 'label', 'src', 'srcLang', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Track'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'default', 'kind', 'label', 'src', 'srcLang', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Track, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Track(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Track(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/U.py
+++ b/dash_html_components/U.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class U(Component):
+    """A U component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'U'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(U, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('U(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'U(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Ul.py
+++ b/dash_html_components/Ul.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Ul(Component):
+    """A Ul component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Ul'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Ul, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Ul(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Ul(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Var.py
+++ b/dash_html_components/Var.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Var(Component):
+    """A Var component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Var'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Var, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Var(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Var(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Video.py
+++ b/dash_html_components/Video.py
@@ -1,0 +1,85 @@
+from dash.development.base_component import Component
+
+
+class Video(Component):
+    """A Video component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- autoPlay (string; optional): The audio or video should play as soon as possible.
+- controls (string; optional): Indicates whether the browser should show playback controls to the user.
+- crossOrigin (string; optional): How the element handles cross-origin requests
+- height (string; optional): Specifies the height of elements listed here. For all other elements, use the CSS height property.        Note: In some instances, such as <div>, this is a legacy attribute, in which case the CSS height property should be used instead.
+- loop (string; optional): Indicates whether the media should start playing from the start when it's finished.
+- muted (string; optional): Indicates whether the audio will be initially silenced on page load.
+- poster (string; optional): A URL indicating a poster frame to show until the user plays or seeks.
+- preload (string; optional): Indicates whether the whole resource, parts of it or nothing should be preloaded.
+- src (string; optional): The URL of the embeddable content.
+- width (string; optional): For the elements listed here, this establishes the element's width.        Note: For all other instances, such as <div>, this is a legacy attribute, in which case the CSS width property should be used instead.
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoPlay', 'controls', 'crossOrigin', 'height', 'loop', 'muted', 'poster', 'preload', 'src', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Video'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'autoPlay', 'controls', 'crossOrigin', 'height', 'loop', 'muted', 'poster', 'preload', 'src', 'width', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Video, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Video(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Video(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Wbr.py
+++ b/dash_html_components/Wbr.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Wbr(Component):
+    """A Wbr component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Wbr'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Wbr, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Wbr(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Wbr(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/Xmp.py
+++ b/dash_html_components/Xmp.py
@@ -1,0 +1,75 @@
+from dash.development.base_component import Component
+
+
+class Xmp(Component):
+    """A Xmp component.
+
+
+Keyword arguments:
+- children (a list of or a singular dash component, string or number; optional): The children of this component
+- id (string; optional): The ID of this component, used to identify dash components
+in callbacks. The ID needs to be unique across all of the
+components in an app.
+- n_clicks (optional): An integer that represents the number of times
+that this element has been clicked on.
+- n_clicks_timestamp (optional): An integer that represents the time (in ms since 1970)
+at which n_clicks changed. This can be used to tell
+which button was changed most recently.
+- key (string; optional): A unique identifier for the component, used to improve
+performance by React.js while rendering components
+See https://reactjs.org/docs/lists-and-keys.html for more info
+- role (string; optional): The ARIA role attribute
+- data-* (string; optional): A wildcard data attribute
+- aria-* (string; optional): A wildcard aria attribute
+- accessKey (string; optional): Defines a keyboard shortcut to activate or add focus to the element.
+- className (string; optional): Often used with CSS to style elements with common properties.
+- contentEditable (string; optional): Indicates whether the element's content is editable.
+- contextMenu (string; optional): Defines the ID of a <menu> element which will serve as the element's context menu.
+- dir (string; optional): Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+- draggable (string; optional): Defines whether the element can be dragged.
+- hidden (string; optional): Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+- lang (string; optional): Defines the language used in the element.
+- spellCheck (string; optional): Indicates whether spell checking is allowed for the element.
+- style (dict; optional): Defines CSS styles which will override styles previously set.
+- tabIndex (string; optional): Overrides the browser's default tab order and follows the one specified instead.
+- title (string; optional): Text to be displayed in a tooltip when hovering over the element.
+
+Available events: 'click'"""
+    def __init__(self, children=None, **kwargs):
+        self._prop_names = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self._type = 'Xmp'
+        self._namespace = 'lib'
+        self._valid_wildcard_attributes =            ['data-', 'aria-']
+        self.available_events = ['click']
+        self.available_properties = ['children', 'id', 'n_clicks', 'n_clicks_timestamp', 'key', 'role', 'data-*', 'aria-*', 'accessKey', 'className', 'contentEditable', 'contextMenu', 'dir', 'draggable', 'hidden', 'lang', 'spellCheck', 'style', 'tabIndex', 'title']
+        self.available_wildcard_properties =            ['data-', 'aria-']
+
+        for k in []:
+            if k not in kwargs:
+                raise TypeError(
+                    'Required argument `' + k + '` was not specified.')
+
+        super(Xmp, self).__init__(children=children, **kwargs)
+
+    def __repr__(self):
+        if(any(getattr(self, c, None) is not None
+               for c in self._prop_names
+               if c is not self._prop_names[0])
+           or any(getattr(self, c, None) is not None
+                  for c in self.__dict__.keys()
+                  if any(c.startswith(wc_attr)
+                  for wc_attr in self._valid_wildcard_attributes))):
+            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self._prop_names
+                                      if getattr(self, c, None) is not None])
+            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
+                                      for c in self.__dict__.keys()
+                                      if any([c.startswith(wc_attr)
+                                      for wc_attr in
+                                      self._valid_wildcard_attributes])])
+            return ('Xmp(' + props_string +
+                   (', ' + wilds_string if wilds_string != '' else '') + ')')
+        else:
+            return (
+                'Xmp(' +
+                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_html_components/__init__.py
+++ b/dash_html_components/__init__.py
@@ -2,6 +2,8 @@ from __future__ import print_function as _
 
 import os as _os
 import sys as _sys
+import glob as _glob
+from importlib import import_module as _import
 
 import dash as _dash
 
@@ -15,22 +17,39 @@ if not hasattr(_dash, 'development'):
 
 _current_path = _os.path.dirname(_os.path.abspath(__file__))
 
-_components = _dash.development.component_loader.load_components(
-    _os.path.join(_current_path, 'metadata.json'),
-    'dash_html_components'
+_component_files = map(
+    lambda x: _os.path.splitext(_os.path.basename(x))[0],
+    filter(
+        lambda x: _os.path.basename(x) not in ['__init__.py', 'version.py'],
+        _glob.glob(_os.path.join(_current_path, '*.py'))
+    )
 )
+
+_components = [
+    getattr(
+        _import(".{:s}".format(c), package='dash_html_components'),
+        c
+    ) for c in _component_files
+]
 
 _this_module = _sys.modules[__name__]
 
-_js_dist = [{
-    "relative_package_path": "bundle.js",
-    "external_url": (
-        "https://unpkg.com/dash-html-components@{}"
-        "/dash_html_components/bundle.js"
-    ).format(__version__),
-    "namespace": "dash_html_components"
-}]
 
-for component in _components:
-    setattr(_this_module, component.__name__, component)
-    setattr(component, '_js_dist', _js_dist)
+_js_dist = [
+    {
+        "relative_package_path": "bundle.js",
+        "external_url": (
+            "https://unpkg.com/dash-html-components@{}"
+            "/dash_html_components/bundle.js"
+        ).format(__version__),
+        "namespace": "dash_html_components"
+    }
+]
+
+_css_dist = []
+
+
+for _component in _components:
+    setattr(_this_module, _component.__name__, _component)
+    setattr(_component, '_js_dist', _js_dist)
+    setattr(_component, '_css_dist', _css_dist)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-html-components",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Vanilla HTML components for Dash",
   "main": "lib/index.js",
   "repository": {
@@ -29,12 +29,12 @@
   "author": "Chris Parmer <chris@plot.ly>",
   "dependencies": {
     "builder": "3.2.1",
-    "dash-components-archetype": "^0.2.4",
+    "dash-components-archetype": "^0.3.0",
     "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "cheerio": "^0.20.0",
-    "dash-components-archetype-dev": "^0.2.4",
+    "dash-components-archetype-dev": "^0.3.0",
     "request": "^2.72.0",
     "string": "^3.3.1"
   },


### PR DESCRIPTION
Solves (https://github.com/plotly/dash/issues/150), see (https://github.com/plotly/dash/pull/271).

Changes version to 0.12.0

* Adds all `ClassName.py` files to `dash_html_components` as generated by `dash.development.component_loader.generate_classes`
* Changes `dash_html_components/__init__.py` to load components via class imports rather than generating at runtime.