### PR TITLE
Only enable percy for one container.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       - image: circleci/python:2.7-stretch-node-browsers
         environment:
           PYTHON_VERSION: py27
+          PERCY_ENABLE: 1
 
     working_directory: ~/repo
 
@@ -64,6 +65,7 @@ jobs:
       - image: circleci/python:3.6-stretch-node-browsers
         environment:
           PYTHON_VERSION: py36
+          PERCY_ENABLE: 0
 
   "python-3.7":
     <<: *test-template
@@ -71,6 +73,7 @@ jobs:
       - image: circleci/python:3.7-stretch-node-browsers
         environment:
           PYTHON_VERSION: py37
+          PERCY_ENABLE: 0
 
 workflows:
   version: 2


### PR DESCRIPTION
Only run percy in python 2.7, plotly/dash#370.