### PR TITLE
Fix MANIFEST.in typo.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include dash_html_components/dash_html_components.min.js
-include_dash_html_components/dash_html_components.dev.js
+include dash_html_components/dash_html_components.dev.js
 include dash_html_components/bundle.js.map
 include dash_html_components/metadata.json
 include README.md


### PR DESCRIPTION
Made a typo in the MANIFEST.in preventing the dev bundle from being included in the build. I've noticed before uploading to pypi and fixed before releasing 0.13.0.