### PR TITLE
Improve ignores & setup.py

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,4 +6,7 @@ venv/
 *.pyc
 *.log
 .DS_Store
-
+.idea
+tests
+dist
+.circleci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [UNRELEASED] - 2018-12-17
 ### Changed
 - Added `.idea`, `tests`, `dist`, `.circleci` to npmignore.
-- Added repository url to setup.py
+- Added repository url and long_description to setup.py
 
 ## [0.13.4] - 2018-12-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED] - 2018-12-17
+### Changed
+- Added `.idea`, `tests`, `dist`, `.circleci` to npmignore.
+- Added repository url to setup.py
+
 ## [0.13.4] - 2018-12-17
 ### Fixed
 - Fix build from wrong dash version.

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import io
 from setuptools import setup
 
 main_ns = {}
@@ -13,5 +14,7 @@ setup(
     include_package_data=True,
     license='MIT',
     description='Dash UI HTML component suite',
+    long_description=io.open('README.md', encoding='utf-8').read(),
+    long_description_content_type='text/markdown',
     install_requires=['dash']
 )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     author='Chris Parmer',
     author_email='chris@plot.ly',
     packages=['dash_html_components'],
+    url='https://github.com/plotly/dash-html-components',
     include_package_data=True,
     license='MIT',
     description='Dash UI HTML component suite',


### PR DESCRIPTION
Noticed a few improvements to be made while publishing 0.13.3/0.13.4

- Added `.idea`, `tests`, `dist`, `.circleci` to npmignore.
- Added repository url to setup.py