### PR TITLE
Percy snapshot name only uses python major/minor

### DIFF
--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -9,7 +9,7 @@ import percy
 class IntegrationTests(unittest.TestCase):
 
     def percy_snapshot(cls, name=''):
-        snapshot_name = '{} - {}'.format(name, sys.version_info)
+        snapshot_name = '{} - {}.{}'.format(name, sys.version_info.major, sys.version_info.minor)
         print(snapshot_name)
         cls.percy_runner.snapshot(
             name=snapshot_name

--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -9,7 +9,7 @@ import percy
 class IntegrationTests(unittest.TestCase):
 
     def percy_snapshot(cls, name=''):
-        snapshot_name = '{} - {}.{}'.format(name, sys.version_info.major, sys.version_info.minor)
+        snapshot_name = '{} - py{}.{}'.format(name, sys.version_info.major, sys.version_info.minor)
         print(snapshot_name)
         cls.percy_runner.snapshot(
             name=snapshot_name


### PR DESCRIPTION
Changing the percy snapshot name w/ python version here too but it's not being used at the moment.