### PR TITLE
June 2019 update component gen, and save updated attributes.html

### DIFF
--- a/scripts/data/attributes.html
+++ b/scripts/data/attributes.html
@@ -1,96 +1,163 @@
+
+
+
 <!DOCTYPE html>
-<html lang="en-US" dir="ltr" class="redesign no-js"  data-ffo-opensanslight=false data-ffo-opensans=false >
+<html lang="en" dir="ltr" class="no-js">
 <head prefix="og: http://ogp.me/ns#">
   <meta charset="utf-8">
+
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <script>(function(d) { d.className = d.className.replace(/\bno-js/, ''); })(document.documentElement);</script>
-
-
-
-
-
-  <title>HTML attribute reference - HTML | MDN</title>
+  <title>HTML attribute reference - HTML: Hypertext Markup Language | MDN</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="index, follow">
-  <link rel="home" href="/en-US/">
-  <link rel="copyright" href="#copyright">
 
 
-
-
-    <link href="https://developer.cdn.mozilla.net/static/build/styles/mdn.593f20d8c365.css" rel="stylesheet" type="text/css" />
-
-
-
-    <link href="https://developer.cdn.mozilla.net/static/build/styles/wiki.328342d23d10.css" rel="stylesheet" type="text/css" />
+<link rel="preload" href="https://developer.mozilla.org/static/fonts/locales/ZillaSlab-Regular.subset.bbc33fb47cf6.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="home" href="/en-US/">
+    <link rel="license" href="#license">
 
 
 
 
 
 
-  <!-- common social tags -->
+    <link href="https://developer.mozilla.org/static/build/styles/mdn.c9fc1dfd8eea.css" rel="stylesheet" type="text/css" />
 
-  <meta property="og:type" content="website">
-  <meta property="og:image" content="https://developer.cdn.mozilla.net/static/img/opengraph-logo.dc4e08e2f6af.png">
-  <meta property="og:site_name" content="Mozilla Developer Network">
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:image" content="https://developer.cdn.mozilla.net/static/img/opengraph-logo.dc4e08e2f6af.png">
-  <meta name="twitter:site" content="@MozDevNet">
-  <meta name="twitter:creator" content="@MozDevNet">
 
-  <link rel="search" type="application/opensearchdescription+xml" href="https://developer.mozilla.org/en-US/search/xml" title="Mozilla Developer Network">
+
+    <link href="https://developer.mozilla.org/static/build/styles/wiki.a853d23bdcec.css" rel="stylesheet" type="text/css" />
+
+
+
+
+  <link href="https://developer.mozilla.org/static/build/styles/locale-en-US.520ecdcaef8c.css" rel="stylesheet" type="text/css" />
+
+
+    <script>
+    // Mozilla DNT Helper
+    /* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */ if(typeof Mozilla==='undefined'){var Mozilla={}}Mozilla.dntEnabled=function(dnt,ua){'use strict';var dntStatus=dnt||navigator.doNotTrack||window.doNotTrack||navigator.msDoNotTrack;var userAgent=ua||navigator.userAgent;var anomalousWinVersions=['Windows NT 6.1','Windows NT 6.2','Windows NT 6.3'];var fxMatch=userAgent.match(/Firefox\/(\d+)/);var ieRegEx=/MSIE|Trident/i;var isIE=ieRegEx.test(userAgent);var platform=userAgent.match(/Windows.+?(?=;)/g);if(isIE&&typeof Array.prototype.indexOf!=='function'){return false}else if(fxMatch&&parseInt(fxMatch[1],10)<32){dntStatus='Unspecified'}else if(isIE&&platform&&anomalousWinVersions.indexOf(platform.toString())!==-1){dntStatus='Unspecified'}else{dntStatus={'0':'Disabled','1':'Enabled'}[dntStatus]||'Unspecified'}return dntStatus==='Enabled'?true:false};
+    // only load GA if DNT is not enabled
+    if (Mozilla && !Mozilla.dntEnabled()) {
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+        ga('create', 'UA-36116321-5', 'mozilla.org');
+        ga('set', 'anonymizeIp', true);
+
+
+
+        // dimension9 == "Section editing"
+
+            // dimension12 == 'Page Revision'
+            ga('set', 'dimension12', '1550064');
+            // dimension17 == 'English Slug'
+            ga('set', 'dimension17', 'Web/HTML/Attributes');
+
+        (function() {
+            // http://cfsimplicity.com/61/removing-analytics-clutter-from-campaign-urls
+            var win = window;
+            var removeUtms = function(){
+                var location = win.location;
+                if (location.href.indexOf('utm') != -1 && win.history.replaceState) {
+                    win.history.replaceState({}, '', location.pathname);
+                }
+            };
+
+            ga('send', 'pageview', {'hitCallback': removeUtms});
+        })();
+    }
+</script>
+
+
+
+    <script>
+LUX=(function(){var a=("undefined"!==typeof(LUX)&&"undefined"!==typeof(LUX.gaMarks)?LUX.gaMarks:[]);var d=("undefined"!==typeof(LUX)&&"undefined"!==typeof(LUX.gaMeasures)?LUX.gaMeasures:[]);var j="LUX_start";var k=window.performance;var l=("undefined"!==typeof(LUX)&&LUX.ns?LUX.ns:(Date.now?Date.now():+(new Date())));if(k&&k.timing&&k.timing.navigationStart){l=k.timing.navigationStart}function f(){if(k&&k.now){return k.now()}var o=Date.now?Date.now():+(new Date());return o-l}function b(n){if(k){if(k.mark){return k.mark(n)}else{if(k.webkitMark){return k.webkitMark(n)}}}a.push({name:n,entryType:"mark",startTime:f(),duration:0});return}function m(p,t,n){if("undefined"===typeof(t)&&h(j)){t=j}if(k){if(k.measure){if(t){if(n){return k.measure(p,t,n)}else{return k.measure(p,t)}}else{return k.measure(p)}}else{if(k.webkitMeasure){return k.webkitMeasure(p,t,n)}}}var r=0,o=f();if(t){var s=h(t);if(s){r=s.startTime}else{if(k&&k.timing&&k.timing[t]){r=k.timing[t]-k.timing.navigationStart}else{return}}}if(n){var q=h(n);if(q){o=q.startTime}else{if(k&&k.timing&&k.timing[n]){o=k.timing[n]-k.timing.navigationStart}else{return}}}d.push({name:p,entryType:"measure",startTime:r,duration:(o-r)});return}function h(n){return c(n,g())}function c(p,o){for(i=o.length-1;i>=0;i--){var n=o[i];if(p===n.name){return n}}return undefined}function g(){if(k){if(k.getEntriesByType){return k.getEntriesByType("mark")}else{if(k.webkitGetEntriesByType){return k.webkitGetEntriesByType("mark")}}}return a}return{mark:b,measure:m,gaMarks:a,gaMeasures:d}})();LUX.ns=(Date.now?Date.now():+(new Date()));LUX.ac=[];LUX.cmd=function(a){LUX.ac.push(a)};LUX.init=function(){LUX.cmd(["init"])};LUX.send=function(){LUX.cmd(["send"])};LUX.addData=function(a,b){LUX.cmd(["addData",a,b])};LUX_ae=[];window.addEventListener("error",function(a){LUX_ae.push(a)});LUX_al=[];if("function"===typeof(PerformanceObserver)){var LongTaskObserver=new PerformanceObserver(function(c){var b=c.getEntries();for(var a=0;a<b.length;a++){var d=b[a];LUX_al.push(d)}});try{LongTaskObserver.observe({entryTypes:["longtask"],buffered:true})}catch(e){}};
+</script>
+<script src="https://cdn.speedcurve.com/js/lux.js?id=108906238" async defer crossorigin="anonymous"></script>
+
+
+
+    <script>
+    // util for setting performance marks and mesaures
+    var mdn=window.mdn||{};mdn.perf={getDuration:function(e){"use strict";if(void 0!==performance.getEntriesByName)return performance.getEntriesByName(e)[0].duration;console.error("performance.getEntriesByName is not supported by your user-agent")},setMark:function(e){"use strict";if(void 0!==performance.mark)try{performance.mark(e)}catch(e){console.error("Error while setting performance mark: ",e)}else console.error("performance.mark is not supported by your user-agent")},setMeasure:function(e){"use strict";void 0!==performance.measure?performance.measure(e.measureName,e.startMark,e.endMark):console.error("performance.measure is not supported by your user-agent")}};
+    /* util specifically for postMessages sent from the
+       `head` of the interactive examples iframe */
+    function handlePerfMarks(e){e.measureName?(window.mdn.perf.setMark(e.markName),window.mdn.perf.setMeasure({measureName:e.measureName,startMark:e.startMark,endMark:e.endMark}),ga&&ga.create&&ga("send",{hitType:"timing",timingCategory:"RUM - Interactive Examples",timingVar:e.measureName,timingValue:window.mdn.perf.getDuration(e.measureName)||0})):window.mdn.perf.setMark(e.markName)}function perfMsgHandler(e){"use strict";var a=window.mdn.interactiveEditor.editorUrl||"https://interactive-examples.mdn.mozilla.net",r=e.data;if(e.origin!==a)return!1;r.markName&&-1<r.markName.indexOf("interactive-editor-")&&handlePerfMarks(r)}window.addEventListener("message",perfMsgHandler,!1);
+</script>
+
+    <!-- common social tags -->
+
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://developer.mozilla.org/static/img/opengraph-logo.72382e605ce3.png">
+    <meta property="og:site_name" content="MDN Web Docs">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:image" content="https://developer.mozilla.org/static/img/opengraph-logo.72382e605ce3.png">
+    <meta name="twitter:site" content="@MozDevNet">
+    <meta name="twitter:creator" content="@MozDevNet">
+    <link rel="search" type="application/opensearchdescription+xml" href="https://developer.mozilla.org/en-US/search/xml" title="MDN Web Docs">
+
 
   <!-- third-generation iPad with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://developer.cdn.mozilla.net/static/img/favicon144.a6e4162070f4.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://developer.mozilla.org/static/img/favicon144.e7e21ca263ca.png">
   <!-- iPhone with high-resolution Retina display: -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://developer.cdn.mozilla.net/static/img/favicon114.0e9fabd44f85.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://developer.mozilla.org/static/img/favicon114.d526f38b09c5.png">
   <!-- first- and second-generation iPad: -->
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://developer.cdn.mozilla.net/static/img/favicon72.8ff9d87c82a0.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://developer.mozilla.org/static/img/favicon72.cc65d1d762a0.png">
   <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-  <link rel="apple-touch-icon-precomposed" href="https://developer.cdn.mozilla.net/static/img/favicon57.a2490b9a2d76.png">
+  <link rel="apple-touch-icon-precomposed" href="https://developer.mozilla.org/static/img/favicon57.de33179910ae.png">
   <!-- basic favicon -->
-
-
-
-  <link rel="shortcut icon" href="https://developer.cdn.mozilla.net/static/img/favicon32.e02854fdcf73.png">
+  <link rel="shortcut icon" href="https://developer.mozilla.org/static/img/favicon32.7f3da72dcea1.png">
   <!--[if IE]>
   <meta http-equiv="imagetoolbar" content="no">
-  <script type="text/javascript" src="https://developer.cdn.mozilla.net/static/build/js/html5shiv.3948ccddab6f.js" charset="utf-8"></script>
+  <script type="text/javascript" src="https://developer.mozilla.org/static/build/js/html5shiv.ae1ac46eaf58.js" charset="utf-8"></script>
   <![endif]-->
 
 
-  <link rel="alternate" type="application/json" href="/en-US/docs/Web/HTML/Attributes$json">
+  <link rel="dns-prefetch" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
+  <link rel="preconnect" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
+
+  <link rel="alternate" type="application/json" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes$json">
   <link rel="canonical" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes" >
 
 
+  <link rel="alternate" hreflang="en" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes" title="HTML attribute reference">
 
-      <link rel="alternate" hreflang="bn-BD" href="/bn-BD/docs/Web/HTML/Attributes" title="HTML অ্যাট্রিবিউট রেফারেন্স">
 
-      <link rel="alternate" hreflang="es" href="/es/docs/Web/HTML/Atributos" title="Guía de Referencia de Atributos HTML">
+      <link rel="alternate" hreflang="bn" href="https://developer.mozilla.org/bn-BD/docs/Web/HTML/Attributes" title="HTML অ্যাট্রিবিউট রেফারেন্স">
 
-      <link rel="alternate" hreflang="fa" href="/fa/docs/HTML/Attributes" title="مرجع صفتهای HTML">
+      <link rel="alternate" hreflang="de" href="https://developer.mozilla.org/de/docs/Web/HTML/Attributes" title="HTML attribute reference">
 
-      <link rel="alternate" hreflang="fr" href="/fr/docs/Web/HTML/Attributes" title="Liste des attributs HTML">
+      <link rel="alternate" hreflang="es" href="https://developer.mozilla.org/es/docs/Web/HTML/Atributos" title="Referencia de Atributos HTML">
 
-      <link rel="alternate" hreflang="it" href="/it/docs/Web/HTML/Attributi" title="Attributi">
+      <link rel="alternate" hreflang="fa" href="https://developer.mozilla.org/fa/docs/HTML/Attributes" title="مرجع صفت‌های HTML">
 
-      <link rel="alternate" hreflang="ja" href="/ja/docs/Web/HTML/Attributes" title="属性 (HTML)">
+      <link rel="alternate" hreflang="fr" href="https://developer.mozilla.org/fr/docs/Web/HTML/Attributs" title="Liste des attributs HTML">
 
-      <link rel="alternate" hreflang="ko" href="/ko/docs/Web/HTML/Attributes" title="HTML attribute reference">
+      <link rel="alternate" hreflang="it" href="https://developer.mozilla.org/it/docs/Web/HTML/Attributi" title="Attributi">
 
-      <link rel="alternate" hreflang="ms" href="/ms/docs/HTML/Sifat-sifat" title="Sifat-sifat">
+      <link rel="alternate" hreflang="ja" href="https://developer.mozilla.org/ja/docs/Web/HTML/Attributes" title="HTML 属性リファレンス">
 
-      <link rel="alternate" hreflang="pt-BR" href="/pt-BR/docs/HTML/Attributes" title="Atributos">
+      <link rel="alternate" hreflang="ko" href="https://developer.mozilla.org/ko/docs/Web/HTML/Attributes" title="HTML attribute reference">
 
-      <link rel="alternate" hreflang="ro" href="/ro/docs/Web/HTML/Atribute" title="Referință de atribute HTML">
+      <link rel="alternate" hreflang="ms" href="https://developer.mozilla.org/ms/docs/HTML/Sifat-sifat" title="Sifat-sifat">
 
-      <link rel="alternate" hreflang="ru" href="/ru/docs/Web/HTML/Attributes" title="Справочная информация по HTML атрибутам">
+      <link rel="alternate" hreflang="pt-BR" href="https://developer.mozilla.org/pt-BR/docs/HTML/Attributes" title="Atributos">
 
-      <link rel="alternate" hreflang="zh-CN" href="/zh-CN/docs/Web/HTML/Attributes" title="HTML 属性参考">
+      <link rel="alternate" hreflang="pt" href="https://developer.mozilla.org/pt-PT/docs/Web/HTML/Atributos" title="Lista de atributos HTML">
 
-      <link rel="alternate" hreflang="zh-TW" href="/zh-TW/docs/Web/HTML/Attributes" title="HTML attribute reference">
+      <link rel="alternate" hreflang="ro" href="https://developer.mozilla.org/ro/docs/Web/HTML/Atribute" title="Referință de atribute HTML">
+
+      <link rel="alternate" hreflang="ru" href="https://developer.mozilla.org/ru/docs/Web/HTML/Attributes" title="Справочная информация по HTML атрибутам">
+
+      <link rel="alternate" hreflang="uk" href="https://developer.mozilla.org/uk/docs/Web/HTML/Attributes" title="HTML attribute reference">
+
+      <link rel="alternate" hreflang="zh" href="https://developer.mozilla.org/zh-CN/docs/Web/HTML/Attributes" title="HTML 属性参考">
+
+      <link rel="alternate" hreflang="zh-TW" href="https://developer.mozilla.org/zh-TW/docs/Web/HTML/Attributes" title="HTML attribute reference">
 
 
 
@@ -100,59 +167,26 @@
   <meta name="twitter:url" content="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes">
   <meta name="twitter:title" content="HTML attribute reference">
 
-  <meta property="og:description" content="Elements in HTML have attributes ; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.">
-  <meta name="description" content="Elements in HTML have attributes ; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.">
-  <meta name="twitter:description" content="Elements in HTML have attributes ; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.">
-
-
-
-
-
-
-<script type="text/javascript">
-
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-36116321-5', 'mozilla.org');
-    ga('set', 'anonymizeIp', true);
-
-
-
-    // dimension9 == "Section editing"
-
-
-    (function() {
-        // http://cfsimplicity.com/61/removing-analytics-clutter-from-campaign-urls
-        var win = window;
-        var removeUtms = function(){
-            var location = win.location;
-            if (location.href.indexOf('utm') != -1 && win.history.replaceState) {
-                win.history.replaceState({}, '', location.pathname);
-            }
-        };
-
-        ga('send', 'pageview', {'hitCallback': removeUtms});
-    })();
-</script>
+  <meta property="og:description" content="Elements in HTML have attributes; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.">
+  <meta name="description" content="Elements in HTML have attributes; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.">
+  <meta name="twitter:description" content="Elements in HTML have attributes; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.">
 
 
 </head>
-<body data-slug="Web/HTML/Attributes" contextmenu="edit-history-menu" data-search-url="" class="document  ">
+<body data-slug="Web/HTML/Attributes" contextmenu="edit-history-menu" data-search-url="" class="document">
 
-  <script type="text/javascript">
+  <script>
+    // make sure global mdn object exists
+    var mdn = window.mdn || {};
+
     (function(win) {
         'use strict';
-
-
             (function(){
   var FLAGS = {
-    'compat_api': false,'kumaediting': false,'page_move': false,'registration_disabled': false,'search_suggestions': false,'section_edit': false,'spam_admin_override': false,'spam_checks_enabled': true,'spam_spammer_override': false,'spam_submissions_enabled': false,'spam_testing_mode': false,'wiki_samples': true,'wiki_spam_exempted': false,'wiki_spam_training': false
+    'kumaediting': false,'page_move': false,'section_edit': false,'spam_checks_enabled': true,'spam_submissions_enabled': false,'spam_admin_override': false,'spam_spammer_override': false,'spam_testing_mode': false,'sg_task_completion': false,'contrib_beta': false,'recurring_payment_beta': false
     },
     SWITCHES = {
-    'wiki_error_on_delete': false,'wiki_force_immediate_rendering': false,'enable_optimizely': false,'welcome_email': true,'application_ACAO': true,'store_revision_ips': true,'dumb_doc_urls': true
+    'welcome_email': true,'application_ACAO': true,'store_revision_ips': true,'foundation_callout': false,'helpful-survey-2': true,'wiki_spam_training': true,'registration_disabled': false
     },
     SAMPLES = {
 
@@ -177,176 +211,180 @@
 })();
 
 
+            // This needs to be set before ckeditor.js loads
+            window.CKEDITOR_BASEPATH = 'https://developer.mozilla.org/static/js/libs/ckeditor4/build/ckeditor/';
 
-        // This needs to be set before ckeditor.js loads
-        window.CKEDITOR_BASEPATH = '/static/js/libs/ckeditor/build/ckeditor/';
+            // Site configuration
+            win.mdn.ckeditor = {};
 
-        // This represents the site configuration
-        win.mdn = {
-            // Properties and settings for CKEditor will go here
-            ckeditor: {},
-            // Feature test results and methods will be placed here
-            features: {},
-            // The path to static assets (images, CSS, JS) in MDN
-            staticPath: 'https://developer.cdn.mozilla.net/static/',
-            // Optimizely API
-            optimizely: win['optimizely'] || [],
-            // Site notifications
+        win.mdn.features = {};
+        win.mdn.siteUrl = 'https://developer.mozilla.org';
+        win.mdn.wikiSiteUrl = 'https://wiki.developer.mozilla.org';
+        win.mdn.staticPath = 'https://developer.mozilla.org/static/';
+        win.mdn.wiki = {
+            autosuggestTitleUrl: '/en-US/docs/get-documents'
+        };
+        win.mdn.assets = {
+            css: {
+                'editor-content': ['https://developer.mozilla.org/static/build/styles/editor-content.3d0c6aceec1e.css','https://developer.mozilla.org/static/build/styles/editor-locale-en-US.520ecdcaef8c.css',
+                ],
 
-            notifications: [],
-
-            // Wiki-specific settings will be placed here
-            wiki: {
-                autosuggestTitleUrl: '/en-US/docs/get-documents'
+                'wiki-compat-tables': ['https://developer.mozilla.org/static/build/styles/wiki-compat-tables.eef64bf9b6fe.css',]
             },
-            // Assets that need to be dynamically injected
-            assets: {
-                css: {
-                    'editor-content': ['https://developer.cdn.mozilla.net/static/build/styles/editor-content.ac1d619a5cc3.css',],
-                    'wiki-compat-tables': ['https://developer.cdn.mozilla.net/static/build/styles/wiki-compat-tables.f3a3bfce97a1.css',]
-                },
-                js: {
-                    'syntax-prism': ['https://developer.cdn.mozilla.net/static/build/js/syntax-prism.7a66ddfa68bf.js',],
-                    'wiki-compat-tables': ['https://developer.cdn.mozilla.net/static/build/js/wiki-compat-tables.14ce5dcb2c3d.js',]
-                }
+            js: {
+                'syntax-prism': ['https://developer.mozilla.org/static/build/js/syntax-prism.f016806edde4.js',],
+                'wiki-compat-tables': ['https://developer.mozilla.org/static/build/js/wiki-compat-tables.3a4ab2cc8ca1.js',]
             }
         };
+
+        win.mdn.notifications = [];
+
+
+
+        // interactive editor config
+        win.mdn.interactiveEditor = {
+            siteUrl: "https://developer.mozilla.org",
+            editorUrl: "https://interactive-examples.mdn.mozilla.net"
+        };
+        win.mdn.langCookieName = "django_language";
+
     })(this);
 </script>
 
+    <ul id="nav-access">
+  <li><a href="#content" id="skip-main">Skip to main content</a></li>
+  <li><a id="skip-language" href="#language">Select language</a></li>
+  <li><a href="#q" id="skip-search">Skip to search</a></li>
+</ul>
 
-
-  <ul id="nav-access">
-    <li><a href="#document-main" id="skip-main">Skip to main content</a></li>
-    <li><a id="skip-language" href="#language">Select language</a></li>
-
-      <li><a href="#q" id="skip-search">Skip to search</a></li>
-
-  </ul>
-
-  <!-- Header -->
-  <header id="main-header"><div class="center">
-
-    <div id="tabzilla">
-        <a href="//www.mozilla.org/" class="no-track">mozilla</a>
-    </div>
-
-    <div class="clear header-clear"></div>
-
-
-    <a href="/en-US/" class="logo">Mozilla Developer Network</a>
-
-
-    <div id="nav-sec">
-
+    <!-- Header -->
+    <header id="main-header" class="header-main">
+      <a href="/en-US/" class="logo">MDN Web Docs</a>
+      <div class="nav-toolbox-wrapper">
+        <nav id="main-nav" class="nav-main" role="navigation">
+    <ul>
+        <li class="nav-main-item">
+            <a href="/en-US/docs/Web">Technologies
+                <svg class="icon icon-caret-down" xmlns="http://www.w3.org/2000/svg" width="16" height="28" viewBox="0 0 16 28"><path d="M16 11a.99.99 0 0 1-.297.703l-7 7C8.516 18.89 8.265 19 8 19s-.516-.109-.703-.297l-7-7A.996.996 0 0 1 0 11c0-.547.453-1 1-1h14c.547 0 1 .453 1 1z"/></svg>
+            </a>
+            <div class="submenu js-submenu" id="nav-tech-submenu">
+                <div class="submenu-column">
                   <ul>
+                    <li><a href="/en-US/docs/Web/HTML">HTML</a></li>
+                    <li><a href="/en-US/docs/Web/CSS">CSS</a></li>
+                    <li><a href="/en-US/docs/Web/JavaScript">JavaScript</a></li>
+                    <li><a href="/en-US/docs/Web/Guide/Graphics">Graphics</a></li>
+                    <li><a href="/en-US/docs/Web/HTTP">HTTP</a></li>
+                    <li><a href="/en-US/docs/Web/API">APIs / DOM</a></li>
+                    <li><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions">Browser Extensions</a></li>
+                    <li><a href="/en-US/docs/Web/MathML">MathML</a></li>
+                  </ul>
+                </div>
+            </div>
+        </li>
+        <li class="nav-main-item">
+            <a href="/en-US/docs/Learn">References & Guides
+                <svg class="icon icon-caret-down" xmlns="http://www.w3.org/2000/svg" width="16" height="28" viewBox="0 0 16 28"><path d="M16 11a.99.99 0 0 1-.297.703l-7 7C8.516 18.89 8.265 19 8 19s-.516-.109-.703-.297l-7-7A.996.996 0 0 1 0 11c0-.547.453-1 1-1h14c.547 0 1 .453 1 1z"/></svg>
+            </a>
+            <div class="submenu js-submenu" id="nav-learn-submenu">
+                <div class="submenu-column">
+                  <ul>
+                    <li><a href="/en-US/docs/Learn">Learn web development</a></li>
+                    <li><a href="/en-US/docs/Web/Tutorials">Tutorials</a></li>
+                    <li><a href="/en-US/docs/Web/Reference">References</a></li>
+                    <li><a href="/en-US/docs/Web/Guide">Developer Guides</a></li>
+                    <li><a href="/en-US/docs/Web/Accessibility">Accessibility</a></li>
+                    <li><a href="/en-US/docs/Games">Game development</a></li>
+                    <li><a href="/en-US/docs/Web">...more docs</a></li>
+                  </ul>
+                </div>
+            </div>
+        </li>
+        <li class="nav-main-item">
+            <a href="/en-US/docs/MDN/Feedback">Feedback
+                <svg class="icon icon-caret-down" xmlns="http://www.w3.org/2000/svg" width="16" height="28" viewBox="0 0 16 28"><path d="M16 11a.99.99 0 0 1-.297.703l-7 7C8.516 18.89 8.265 19 8 19s-.516-.109-.703-.297l-7-7A.996.996 0 0 1 0 11c0-.547.453-1 1-1h14c.547 0 1 .453 1 1z"/></svg>
+            </a>
+            <div class="submenu js-submenu" id="nav-contact-submenu">
+              <div class="submenu-column">
+                <ul>
                   <li>
-
-
-
-    <form>
-      <div class="oauth-login-container">
-          <div class="oauth-login-options" tabIndex="0">
-              <span class="oauth-login-options-text">
-                Sign in
-              </span>
-              <span class="oauth-icon oauth-github" data-service="GitHub" data-href="/users/github/login/?next=%2Fen-US%2Fdocs%2FWeb%2FHTML%2FAttributes" title="GitHub"><i class="icon-github" aria-hidden="true"></i></span>
-              <span class="oauth-icon oauth-persona launch-persona-login wait-for-persona disabled" data-service="Persona" data-next="/en-US/docs/Web/HTML/Attributes" title="Persona"><i class="icon-user" aria-hidden="true"></i></span>
-          </div>
-          <div class="oauth-login-picker" aria-hidden="true">
-              <ul>
-                  <li class="wait-for-persona disabled"><a href="/en-US/users/signin" class="login-link launch-persona-login" data-next="/en-US/docs/Web/HTML/Attributes" data-service="Persona"><i class="icon-user" aria-hidden="true"></i>Persona</a></li>
-                  <li><a href="/users/github/login/?next=%2Fen-US%2Fdocs%2FWeb%2FHTML%2FAttributes" class="login-link" data-service="GitHub"><i class="icon-github" aria-hidden="true"></i>GitHub</a></li>
-              </ul>
-
-          </div>
-      </div>
-    </form>
-</li>
+                      <a href="https://support.mozilla.org/">Get Firefox help
+                          <svg class="icon icon-external-link" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28" aria-hidden="true"><path d="M22 14.5v5c0 2.484-2.016 4.5-4.5 4.5h-13A4.502 4.502 0 0 1 0 19.5v-13C0 4.016 2.016 2 4.5 2h11c.281 0 .5.219.5.5v1c0 .281-.219.5-.5.5h-11A2.507 2.507 0 0 0 2 6.5v13C2 20.875 3.125 22 4.5 22h13c1.375 0 2.5-1.125 2.5-2.5v-5c0-.281.219-.5.5-.5h1c.281 0 .5.219.5.5zM28 1v8c0 .547-.453 1-1 1a.99.99 0 0 1-.703-.297l-2.75-2.75L13.36 17.14c-.094.094-.234.156-.359.156s-.266-.063-.359-.156l-1.781-1.781c-.094-.094-.156-.234-.156-.359s.063-.266.156-.359L21.048 4.454l-2.75-2.75a.996.996 0 0 1-.297-.703c0-.547.453-1 1-1h8c.547 0 1 .453 1 1z"/></svg>
+                      </a>
+                  </li>
+                  <li>
+                      <a href="https://stackoverflow.com/">Get web development help
+                          <svg class="icon icon-external-link" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28" aria-hidden="true"><path d="M22 14.5v5c0 2.484-2.016 4.5-4.5 4.5h-13A4.502 4.502 0 0 1 0 19.5v-13C0 4.016 2.016 2 4.5 2h11c.281 0 .5.219.5.5v1c0 .281-.219.5-.5.5h-11A2.507 2.507 0 0 0 2 6.5v13C2 20.875 3.125 22 4.5 22h13c1.375 0 2.5-1.125 2.5-2.5v-5c0-.281.219-.5.5-.5h1c.281 0 .5.219.5.5zM28 1v8c0 .547-.453 1-1 1a.99.99 0 0 1-.703-.297l-2.75-2.75L13.36 17.14c-.094.094-.234.156-.359.156s-.266-.063-.359-.156l-1.781-1.781c-.094-.094-.156-.234-.156-.359s.063-.266.156-.359L21.048 4.454l-2.75-2.75a.996.996 0 0 1-.297-.703c0-.547.453-1 1-1h8c.547 0 1 .453 1 1z"/></svg>
+                      </a>
+                  </li>
                 </ul>
-
-    </div>
-
-    <nav id="main-nav" role="navigation"><ul><li><a href="/en-US/docs/Web">Web Platform<i aria-hidden="true" class="icon-caret-down"></i></a>
-
-        <div class="submenu submenu-cols-2 js-submenu" id="nav-platform-submenu">
-          <div class="submenu-column">
-            <div class="title">Technologies</div>
-            <ul>
-              <li><a href="/en-US/docs/Web/HTML">HTML</a></li>
-              <li><a href="/en-US/docs/Web/CSS">CSS</a></li>
-              <li><a href="/en-US/docs/Web/JavaScript">JavaScript</a></li>
-              <li><a href="/en-US/docs/Web/Guide/Graphics">Graphics</a></li>
-              <li><a href="/en-US/docs/Web/API">APIs / DOM</a></li>
-              <li><a href="/en-US/docs/Web/Apps">Apps</a></li>
-              <li><a href="/en-US/docs/Web/MathML">MathML</a></li>
-            </ul>
-          </div><div class="submenu-column last">
-            <div class="title">References & Guides</div>
-            <ul>
-              <li><a href="/en-US/docs/Learn">Learn the Web</a></li>
-              <li><a href="/en-US/docs/Web/Tutorials">Tutorials</a></li>
-              <li><a href="/en-US/docs/Web/Reference">References</a></li>
-              <li><a href="/en-US/docs/Web/Guide">Developer Guides</a></li>
-              <li><a href="/en-US/docs/Web/Accessibility">Accessibility</a></li>
-              <li><a href="/en-US/docs/Web">...more docs</a></li>
-            </ul>
+                <ul>
+                  <li>
+                      <a href="/en-US/docs/MDN/Community">Join the MDN community</a>
+                  </li>
+                  <li>
+                      <a target="_blank" rel="noopener" href="https://github.com/mdn/sprints/issues/new?template=issue-template.md&projects=mdn/sprints/2&labels=user-report&title=https%3A//developer.mozilla.org/en-US/docs/Web/HTML/Attributes">Report a content problem
+                          <svg class="icon icon-external-link" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28" aria-hidden="true"><path d="M22 14.5v5c0 2.484-2.016 4.5-4.5 4.5h-13A4.502 4.502 0 0 1 0 19.5v-13C0 4.016 2.016 2 4.5 2h11c.281 0 .5.219.5.5v1c0 .281-.219.5-.5.5h-11A2.507 2.507 0 0 0 2 6.5v13C2 20.875 3.125 22 4.5 22h13c1.375 0 2.5-1.125 2.5-2.5v-5c0-.281.219-.5.5-.5h1c.281 0 .5.219.5.5zM28 1v8c0 .547-.453 1-1 1a.99.99 0 0 1-.703-.297l-2.75-2.75L13.36 17.14c-.094.094-.234.156-.359.156s-.266-.063-.359-.156l-1.781-1.781c-.094-.094-.156-.234-.156-.359s.063-.266.156-.359L21.048 4.454l-2.75-2.75a.996.996 0 0 1-.297-.703c0-.547.453-1 1-1h8c.547 0 1 .453 1 1z"/></svg>
+                      </a>
+                  </li>
+                  <li>
+                      <a target="_blank" rel="noopener" href="https://bugzilla.mozilla.org/form.mdn">Report a bug
+                          <svg class="icon icon-external-link" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28" aria-hidden="true"><path d="M22 14.5v5c0 2.484-2.016 4.5-4.5 4.5h-13A4.502 4.502 0 0 1 0 19.5v-13C0 4.016 2.016 2 4.5 2h11c.281 0 .5.219.5.5v1c0 .281-.219.5-.5.5h-11A2.507 2.507 0 0 0 2 6.5v13C2 20.875 3.125 22 4.5 22h13c1.375 0 2.5-1.125 2.5-2.5v-5c0-.281.219-.5.5-.5h1c.281 0 .5.219.5.5zM28 1v8c0 .547-.453 1-1 1a.99.99 0 0 1-.703-.297l-2.75-2.75L13.36 17.14c-.094.094-.234.156-.359.156s-.266-.063-.359-.156l-1.781-1.781c-.094-.094-.156-.234-.156-.359s.063-.266.156-.359L21.048 4.454l-2.75-2.75a.996.996 0 0 1-.297-.703c0-.547.453-1 1-1h8c.547 0 1 .453 1 1z"/></svg>
+                      </a>
+                  </li>
+                </ul>
+              </div>
           </div>
-        </div>
-      </li><li><a href="/en-US/docs/Zones">Mozilla Docs<i aria-hidden="true" class="icon-caret-down"></i></a>
+      </li>
+  </ul>
+</nav>
+        <div id="toolbox" class="toolbox">
+  <ul>
 
-        <div class="submenu js-submenu" id="nav-zones-submenu">
-          <div class="submenu-column">
-            <ul>
-              <li><a href="/en-US/docs/Mozilla/Add-ons">Add-ons</a></li>
-              <li><a href="/en-US/docs/Mozilla/Firefox">Firefox</a></li>
-              <li><a href="/en-US/docs/Mozilla/Marketplace">Firefox Marketplace</a></li>
-              <li><a href="/en-US/docs/Mozilla/B2G_OS">B2G OS</a></li>
-              <li><a href="/en-US/docs/Persona">Persona</a></li>
-            </ul>
-          </div>
-        </div>
-      </li><li><a href="/en-US/docs/Tools">Developer Tools</a></li><li><a href="/en-US/docs/MDN/Feedback">Feedback<i aria-hidden="true" class="icon-caret-down"></i></a>
+    <li class="nav-login"><div class="login">
 
-        <div class="submenu js-submenu" id="nav-contact-submenu">
-          <div class="submenu-column">
-            <ul>
-                <li><a href="https://support.mozilla.org/">Get Firefox help<i aria-hidden="true" class="icon-external-link"></i></a></li>
-                <li><a href="http://stackoverflow.com/">Get web development help<i aria-hidden="true" class="icon-external-link"></i></a></li>
-            </ul>
-            <ul>
-              <li><a href="/en-US/docs/MDN/Community">Join the MDN community</a></li>
-              <li><a href="https://bugzilla.mozilla.org/form.doc">Report a content problem<i aria-hidden="true" class="icon-external-link"></i></a></li>
-              <li><a href="https://bugzilla.mozilla.org/form.mdn">Report a bug<i aria-hidden="true" class="icon-external-link"></i></a></li>
-            </ul>
-          </div>
-        </div>
 
-      </li><li class="nav-search-link"><a href="/en-US/search" title="Search"><i aria-hidden="true" class="icon-search"></i></a></li><li class="main-nav-search"><form action="/en-US/search" method="get" role="search">
-        <div class="search-wrap">
-          <label for="main-q" class="offscreen">Search</label>
-          <input type="search" id="main-q" name="q" placeholder="Search" data-value="" value="" />
-          <span class="search-trigger"><i aria-hidden="true" class="icon-search"></i></span>&nbsp;
-          <button type="submit" class="offscreen">Search</button>
-        </div>
-      </form></li></ul></nav>
-  </div></header>
+        <a href="/users/github/login/?next=%2Fen-US%2Fdocs%2FWeb%2FHTML%2FAttributes" class="login-link js-login-link" data-service="GitHub" rel="nofollow">
+            Sign in<svg class="icon icon-github" xmlns="http://www.w3.org/2000/svg" width="24" height="28" viewBox="0 0 24 28" aria-label="GitHub" role="img" focusable="false">
+    <title>Github</title>
+    <path d="M12 2c6.625 0 12 5.375 12 12 0 5.297-3.437 9.797-8.203 11.391-.609.109-.828-.266-.828-.578 0-.391.016-1.687.016-3.297 0-1.125-.375-1.844-.812-2.219 2.672-.297 5.484-1.313 5.484-5.922 0-1.313-.469-2.375-1.234-3.219.125-.313.531-1.531-.125-3.187-1-.313-3.297 1.234-3.297 1.234a11.28 11.28 0 0 0-6 0S6.704 6.656 5.704 6.969c-.656 1.656-.25 2.875-.125 3.187-.766.844-1.234 1.906-1.234 3.219 0 4.594 2.797 5.625 5.469 5.922-.344.313-.656.844-.766 1.609-.688.313-2.438.844-3.484-1-.656-1.141-1.844-1.234-1.844-1.234-1.172-.016-.078.734-.078.734.781.359 1.328 1.75 1.328 1.75.703 2.141 4.047 1.422 4.047 1.422 0 1 .016 1.937.016 2.234 0 .313-.219.688-.828.578C3.439 23.796.002 19.296.002 13.999c0-6.625 5.375-12 12-12zM4.547 19.234c.031-.063-.016-.141-.109-.187-.094-.031-.172-.016-.203.031-.031.063.016.141.109.187.078.047.172.031.203-.031zm.484.532c.063-.047.047-.156-.031-.25-.078-.078-.187-.109-.25-.047-.063.047-.047.156.031.25.078.078.187.109.25.047zm.469.703c.078-.063.078-.187 0-.297-.063-.109-.187-.156-.266-.094-.078.047-.078.172 0 .281s.203.156.266.109zm.656.656c.063-.063.031-.203-.063-.297-.109-.109-.25-.125-.313-.047-.078.063-.047.203.063.297.109.109.25.125.313.047zm.891.391c.031-.094-.063-.203-.203-.25-.125-.031-.266.016-.297.109s.063.203.203.234c.125.047.266 0 .297-.094zm.984.078c0-.109-.125-.187-.266-.172-.141 0-.25.078-.25.172 0 .109.109.187.266.172.141 0 .25-.078.25-.172zm.906-.156c-.016-.094-.141-.156-.281-.141-.141.031-.234.125-.219.234.016.094.141.156.281.125s.234-.125.219-.219z"/>
+</svg>
+        </a>
+
+</div></li>
+  </ul>
+</div>
+      </div>
+      <form id="nav-main-search" action="/en-US/search" method="get" role="search" class="nav-main-search">
+  <div class="search-wrap">
+    <label for="main-q" class="offscreen">Search</label>
+    <input type="search" id="main-q" name="q" placeholder="Search" data-value="" value="" aria-hidden="true" />
+    <span class="search-trigger">
+        <svg class="icon icon-search" xmlns="http://www.w3.org/2000/svg" width="26" height="28" viewBox="0 0 26 28" aria-hidden="true">
+    <path d="M18 13c0-3.859-3.141-7-7-7s-7 3.141-7 7 3.141 7 7 7 7-3.141 7-7zm8 13c0 1.094-.906 2-2 2a1.96 1.96 0 0 1-1.406-.594l-5.359-5.344a10.971 10.971 0 0 1-6.234 1.937c-6.078 0-11-4.922-11-11s4.922-11 11-11 11 4.922 11 11c0 2.219-.672 4.406-1.937 6.234l5.359 5.359c.359.359.578.875.578 1.406z"/>
+</svg>
+    </span>
+    <button type="submit" class="offscreen">Search</button>
+    <button type="button" id="close-header-search" class="close-header-search transparent">
+        <span class="offscreen">Close search</span>
+        <svg class="icon icon-close" xmlns="http://www.w3.org/2000/svg" width="22" height="28" viewBox="0 0 22 28" aria-hidden="true" role="img"><title></title><path d="M20.281 20.656c0 .391-.156.781-.438 1.062l-2.125 2.125c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438L11 19.249l-4.594 4.594c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438l-2.125-2.125c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062L6.751 15l-4.594-4.594c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062l2.125-2.125c.281-.281.672-.438 1.062-.438s.781.156 1.062.438L11 10.751l4.594-4.594c.281-.281.672-.438 1.062-.438s.781.156 1.062.438l2.125 2.125c.281.281.438.672.438 1.062s-.156.781-.438 1.062L15.249 15l4.594 4.594c.281.281.438.672.438 1.062z"/></svg>
+    </button>
+  </div>
+</form>
+    </header>
 
   <!-- Content will go here -->
-  <main id="content"><div class="center clear">
+  <main id="content">
 
+  <!-- heading -->
+  <div id="wiki-document-head" class="document-head">
+    <div class="center">
+      <div class="document-title">
+        <h1>HTML attribute reference</h1>
+      </div>
 
-   <!-- end is_zone -->
-
-
-    <div class="wiki-main-content" id="document-main"><div class="center">
-
-      <div class="article-meta">
-        <!-- action buttons -->
-
-
-
-
+      <!-- action buttons -->
+      <div class="document-actions">
 
 
 
@@ -355,66 +393,96 @@
 
 
 
-  <ul class="page-buttons" data-sticky="false">
 
-      <li><button id="languages-menu" class="transparent" aria-haspopup="true" aria-owns="languages-menu-submenu" aria-expanded="false"><span>Languages</span><i aria-hidden="true" class="icon-language"></i></button>
+
+
+
+
+
+
+  <ul class="page-buttons">
+      <li>
+          <button id="languages-menu" class="transparent" aria-haspopup="true" aria-owns="languages-menu-submenu" aria-expanded="false">
+              <svg class="icon icon-language" xmlns="http://www.w3.org/2000/svg" width="24" height="28" viewBox="0 0 24 28" aria-hidden="true">
+    <path d="M10.219 16.844c-.031.109-.797-.25-1-.328-.203-.094-1.125-.609-1.359-.766s-1.125-.891-1.234-.938a28.275 28.275 0 0 1-2.094 2.828c-.281.328-1.125 1.391-1.641 1.719-.078.047-.531.094-.594.063.25-.187.969-1.078 1.281-1.437.391-.453 2.25-3.047 2.562-3.641.328-.594 1.312-2.562 1.359-2.75-.156-.016-1.391.406-1.719.516-.313.094-1.172.297-1.234.344-.063.063-.016.25-.047.313s-.313.203-.484.234a1.647 1.647 0 0 1-.734 0c-.203-.047-.391-.25-.438-.328 0 0-.063-.094-.078-.359.187-.063.5-.078.844-.172s1.188-.344 1.641-.5 1.328-.484 1.594-.547c.281-.047.984-.516 1.359-.641s.641-.281.656-.203 0 .422-.016.516c-.016.078-.766 1.547-.875 1.781-.063.125-.5.953-1.203 2.047.25.109.781.328 1 .438.266.125 2.125.906 2.219.938s.266.75.234.875zM7.016 9.25c.047.266-.031.375-.063.438-.156.297-.547.5-.781.594s-.625.187-.938.187c-.141-.016-.422-.063-.766-.406-.187-.203-.328-.75-.266-.688s.516.125.719.078.688-.187.906-.25c.234-.078.703-.203.859-.219.156 0 .281.063.328.266zm10.906 2.016l.984 3.547-2.172-.656zM.609 23.766l10.844-3.625V4.016L.609 7.657v16.109zM20 18.813l1.594.484-2.828-10.266-1.563-.484-3.375 8.375 1.594.484.703-1.719 3.297 1.016zM12.141 3.781l8.953 2.875V.718zM17 24.453l2.469.203-.844 2.5L18 26.125c-1.266.812-2.828 1.437-4.312 1.687-.453.094-.969.187-1.422.187h-1.313c-1.656 0-4.672-.984-5.984-1.937-.094-.078-.125-.141-.125-.25 0-.172.125-.297.281-.297.141 0 .875.453 1.078.547 1.406.703 3.375 1.344 4.953 1.344 1.953 0 3.281-.25 5.063-1.016.516-.234.969-.531 1.453-.797zm7-16.859v16.859c-12.078-3.844-12.094-3.844-12.094-3.844C11.656 20.718.453 24.5.297 24.5a.3.3 0 0 1-.281-.203c0-.016-.016-.031-.016-.047V7.406c.016-.047.031-.125.063-.156.094-.109.219-.141.313-.172.047-.016 1-.328 2.328-.781v-6l8.719 3.094C11.532 3.36 21.251 0 21.392 0c.172 0 .313.125.313.328v6.531z"/>
+</svg>
+              <span>Languages</span>
+          </button>
 
         <div class="submenu js-submenu" id="languages-menu-submenu">
           <div class="submenu-column">
             <ul id="translations">
 
 
-                  <li><bdi><a rel="internal" href="/bn-BD/docs/Web/HTML/Attributes" title="HTML অ্যাট্রিবিউট রেফারেন্স">বাংলা (বাংলাদেশ)</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/es/docs/Web/HTML/Atributos" title="Guía de Referencia de Atributos HTML">Español</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/fa/docs/HTML/Attributes" title="مرجع صفتهای HTML">فارسی</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/fr/docs/Web/HTML/Attributes" title="Liste des attributs HTML">Français</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/it/docs/Web/HTML/Attributi" title="Attributi">Italiano</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/ja/docs/Web/HTML/Attributes" title="属性 (HTML)">日本語</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/ko/docs/Web/HTML/Attributes" title="HTML attribute reference">한국어</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/ms/docs/HTML/Sifat-sifat" title="Sifat-sifat">Melayu</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/pt-BR/docs/HTML/Attributes" title="Atributos">Português (do Brasil)</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/ro/docs/Web/HTML/Atribute" title="Referință de atribute HTML">Română</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/ru/docs/Web/HTML/Attributes" title="Справочная информация по HTML атрибутам">Русский</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/zh-CN/docs/Web/HTML/Attributes" title="HTML 属性参考">中文 (简体)</a></bdi></li>
-
-                  <li><bdi><a rel="internal" href="/zh-TW/docs/Web/HTML/Attributes" title="HTML attribute reference">正體中文 (繁體)</a></bdi></li>
 
 
+                  <li lang="bn-BD"><bdi><a rel="internal" href="/bn-BD/docs/Web/HTML/Attributes" data-locale="bn-BD" title="Bengali (Bangladesh)">বাংলা (বাংলাদেশ) (bn-BD)</a></bdi></li>
+
+                  <li lang="de"><bdi><a rel="internal" href="/de/docs/Web/HTML/Attributes" data-locale="de" title="German">Deutsch (de)</a></bdi></li>
+
+                  <li lang="es"><bdi><a rel="internal" href="/es/docs/Web/HTML/Atributos" data-locale="es" title="Spanish">Español (es)</a></bdi></li>
+
+                  <li lang="fa"><bdi><a rel="internal" href="/fa/docs/HTML/Attributes" data-locale="fa" title="Persian">فارسی (fa)</a></bdi></li>
+
+                  <li lang="fr"><bdi><a rel="internal" href="/fr/docs/Web/HTML/Attributs" data-locale="fr" title="French">Français (fr)</a></bdi></li>
+
+                  <li lang="it"><bdi><a rel="internal" href="/it/docs/Web/HTML/Attributi" data-locale="it" title="Italian">Italiano (it)</a></bdi></li>
+
+                  <li lang="ja"><bdi><a rel="internal" href="/ja/docs/Web/HTML/Attributes" data-locale="ja" title="Japanese">日本語 (ja)</a></bdi></li>
+
+                  <li lang="ko"><bdi><a rel="internal" href="/ko/docs/Web/HTML/Attributes" data-locale="ko" title="Korean">한국어 (ko)</a></bdi></li>
+
+                  <li lang="ms"><bdi><a rel="internal" href="/ms/docs/HTML/Sifat-sifat" data-locale="ms" title="Malay">Melayu (ms)</a></bdi></li>
+
+                  <li lang="pt-BR"><bdi><a rel="internal" href="/pt-BR/docs/HTML/Attributes" data-locale="pt-BR" title="Portuguese (Brazilian)">Português (do Brasil) (pt-BR)</a></bdi></li>
+
+                  <li lang="pt-PT"><bdi><a rel="internal" href="/pt-PT/docs/Web/HTML/Atributos" data-locale="pt-PT" title="Portuguese (Portugal)">Português (Europeu) (pt-PT)</a></bdi></li>
+
+                  <li lang="ro"><bdi><a rel="internal" href="/ro/docs/Web/HTML/Atribute" data-locale="ro" title="Romanian">Română (ro)</a></bdi></li>
+
+                  <li lang="ru"><bdi><a rel="internal" href="/ru/docs/Web/HTML/Attributes" data-locale="ru" title="Russian">Русский (ru)</a></bdi></li>
+
+                  <li lang="uk"><bdi><a rel="internal" href="/uk/docs/Web/HTML/Attributes" data-locale="uk" title="Ukrainian">Українська (uk)</a></bdi></li>
+
+                  <li lang="zh-CN"><bdi><a rel="internal" href="/zh-CN/docs/Web/HTML/Attributes" data-locale="zh-CN" title="Chinese (Simplified)">中文 (简体) (zh-CN)</a></bdi></li>
+
+                  <li lang="zh-TW"><bdi><a rel="internal" href="/zh-TW/docs/Web/HTML/Attributes" data-locale="zh-TW" title="Chinese (Traditional)">正體中文 (繁體) (zh-TW)</a></bdi></li>
 
 
-                <li><a href="/en-US/docs/Web/HTML/Attributes$locales" rel="nofollow, noindex" id="translations-add">Add a translation</a></li>
+
+
+                <li><a href="/en-US/docs/Web/HTML/Attributes$locales" rel="nofollow" id="translations-add">Add a translation</a></li>
 
             </ul>
           </div>
         </div>
       </li>
 
-      <li class="page-buttons-edit"><a href="/en-US/docs/Web/HTML/Attributes$edit" class="button" data-optimizely-hook="button-edit-doc" id="edit-button">Edit<i aria-hidden="true" class="icon-pencil"></i></a></li>
-
-
-
-        <li><button id="advanced-menu" class="only-icon" aria-haspopup="true" aria-owns="advanced-menu-submenu" aria-expanded="false"><span>Advanced</span><i aria-hidden="true" class="icon-cog"></i></button>
-        <div class="submenu js-submenu" id="advanced-menu-submenu">
-          <!-- this page -->
-          <div class="submenu-column">
-            <div class="title">Advanced</div>
-            <ul>
-                <li><a href="/en-US/docs/Web/HTML/Attributes$history" rel="nofollow, noindex">History</a></li>
+      <li class="page-buttons-edit">
+          <a href="/en-US/users/signin?next=/en-US/docs/Web/HTML/Attributes%24edit" class="button neutral" id="edit-button" rel="nofollow">
+              <svg class="icon icon-pencil" xmlns="http://www.w3.org/2000/svg" width="24" height="28" viewBox="0 0 24 28" aria-hidden="true">
+    <path d="M5.672 24l1.422-1.422-3.672-3.672L2 20.328V22h2v2h1.672zm8.172-14.5a.329.329 0 0 0-.344-.344.368.368 0 0 0-.266.109l-8.469 8.469a.366.366 0 0 0-.109.266c0 .203.141.344.344.344a.368.368 0 0 0 .266-.109l8.469-8.469a.366.366 0 0 0 .109-.266zM13 6.5l6.5 6.5-13 13H0v-6.5zM23.672 8c0 .531-.219 1.047-.578 1.406L20.5 12 14 5.5l2.594-2.578c.359-.375.875-.594 1.406-.594s1.047.219 1.422.594l3.672 3.656c.359.375.578.891.578 1.422z"/>
+</svg>
+              Edit
+          </a>
+      </li>
 
 
 
 
+        <li class="page-buttons-advanced">
+            <button id="advanced-menu" class="only-icon" aria-haspopup="true" aria-owns="advanced-menu-submenu" aria-expanded="false">
+                <svg class="icon icon-gear" xmlns="http://www.w3.org/2000/svg" width="24" height="28" viewBox="0 0 24 28" aria-hidden="true">
+    <path d="M16 14c0-2.203-1.797-4-4-4s-4 1.797-4 4 1.797 4 4 4 4-1.797 4-4zm8-1.703v3.469c0 .234-.187.516-.438.562l-2.891.438a8.86 8.86 0 0 1-.609 1.422c.531.766 1.094 1.453 1.672 2.156.094.109.156.25.156.391s-.047.25-.141.359c-.375.5-2.484 2.797-3.016 2.797a.795.795 0 0 1-.406-.141l-2.156-1.687a9.449 9.449 0 0 1-1.422.594c-.109.953-.203 1.969-.453 2.906a.573.573 0 0 1-.562.438h-3.469c-.281 0-.531-.203-.562-.469l-.438-2.875a9.194 9.194 0 0 1-1.406-.578l-2.203 1.672c-.109.094-.25.141-.391.141s-.281-.063-.391-.172c-.828-.75-1.922-1.719-2.578-2.625a.607.607 0 0 1 .016-.718c.531-.719 1.109-1.406 1.641-2.141a8.324 8.324 0 0 1-.641-1.547l-2.859-.422A.57.57 0 0 1 0 15.705v-3.469c0-.234.187-.516.422-.562l2.906-.438c.156-.5.359-.969.609-1.437a37.64 37.64 0 0 0-1.672-2.156c-.094-.109-.156-.234-.156-.375s.063-.25.141-.359c.375-.516 2.484-2.797 3.016-2.797.141 0 .281.063.406.156L7.828 5.94a9.449 9.449 0 0 1 1.422-.594c.109-.953.203-1.969.453-2.906a.573.573 0 0 1 .562-.438h3.469c.281 0 .531.203.562.469l.438 2.875c.484.156.953.344 1.406.578l2.219-1.672c.094-.094.234-.141.375-.141s.281.063.391.156c.828.766 1.922 1.734 2.578 2.656a.534.534 0 0 1 .109.344c0 .141-.047.25-.125.359-.531.719-1.109 1.406-1.641 2.141.266.5.484 1.016.641 1.531l2.859.438a.57.57 0 0 1 .453.562z"/>
+</svg>
+                <span>Advanced</span>
+            </button>
+            <div class="submenu js-submenu" id="advanced-menu-submenu">
+                <!-- this page -->
+                <div class="submenu-column">
+                    <div class="title">Advanced</div>
+                    <ul>
+                        <li><a href="/en-US/docs/Web/HTML/Attributes$history" rel="nofollow">History</a></li>
 
 
 
@@ -427,218 +495,32 @@
           </div>
         </div>
   </li></ul>
-
-        <!-- crumbs -->
-
-  <nav class="crumbs" role="navigation"><ol xmlns:v="http://rdf.data-vocabulary.org/#" aria-label="breadcrumbs">
-    <li typeof="v:Breadcrumb"><a href="/en-US" rel="v:url" property="v:title">MDN</a></li>
-
-      <li class="crumb" typeof="v:Breadcrumb"><a href="/en-US/docs/Web" rel="v:url" property="v:title">Web technology for developers</a></li>
-
-      <li class="crumb" typeof="v:Breadcrumb"><a href="/en-US/docs/Web/HTML" rel="v:url" property="v:title">HTML</a></li>
-
-    <li class="crumb" typeof="v:Breadcrumb" property="v:title">HTML attribute reference</li>
-  </ol></nav>
       </div>
+    </div>
+  </div>
 
-      <!-- heading -->
-      <div id="wiki-document-head" class="document-head">
-          <span class="from-search-previous-box">
-            <a class="button from-search-previous only-icon disabled" title="Previous Search Result" data-empty-title="No Previous Search Result"><i aria-hidden="true" class="icon-chevron-left"></i></a>
-          </span>
-          <span class="from-search-navigate-wrap">
-            <a href="#" class="from-search-navigate"><span class="from-search-navigate-up"><i aria-hidden="true" class="icon-double-angle-up"></i></span><span class="from-search-navigate-down"><i aria-hidden="true" class="icon-double-angle-down"></i></span></a>
-          </span>
-          <div class="from-search-toc submenu">
-            <span class="title">Your Search Results</span>
-            <ol></ol>
-          </div>
-          <span class="from-search-next-box">
-            <a class="button from-search-next only-icon disabled" title="Next Search Result" data-empty-title="No Previous Search Result"><i aria-hidden="true" class="icon-chevron-right"></i></a>
-          </span>
+  <div id="toc" class="toc">
+    <div class="center">
+      <div class="toc-head">Jump to:</div>
+        <ol class="toc-links">
+          <li><a href="#Attribute_list" rel="internal">Attribute list</a><li><a href="#Content_versus_IDL_attributes" rel="internal">Content versus IDL attributes</a><li><a href="#Boolean_Attributes" rel="internal">Boolean Attributes</a><li><a href="#See_also" rel="internal">See also</a>
+        </ol>
+    </div>
+  </div>
 
 
-        <div class="contributor-avatars" data-all-text="see all contributors" data-alternate-message="hide contributors" data-has-hidden="1">
-            <ul>
-
-                <li class="shown">
-                <a href="/en-US/profiles/piglovesyou" title="View profile: piglovesyou">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="piglovesyou" data-src="https://secure.gravatar.com/avatar/bf8039615ae8ae82e954959ea549404d?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">piglovesyou</noscript></a>
-                </li>
-
-                <li class="shown">
-                <a href="/en-US/profiles/jswisher" title="View profile: jswisher">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="jswisher" data-src="https://secure.gravatar.com/avatar/38185c2812cbcae186ebbe4a82910661?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">jswisher</noscript></a>
-                </li>
-
-                <li class="shown">
-                <a href="/en-US/profiles/leleofg" title="View profile: leleofg">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="leleofg" data-src="https://secure.gravatar.com/avatar/c02223c5f55366b3e183cb0f0db726da?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">leleofg</noscript></a>
-                </li>
-
-                <li class="shown">
-                <a href="/en-US/profiles/Tigt" title="View profile: Tigt">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="Tigt" data-src="https://secure.gravatar.com/avatar/6dfc114d927c3f5bd61c2697b4adf2bc?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">Tigt</noscript></a>
-                </li>
-
-                <li class="shown">
-                <a href="/en-US/profiles/Sheppy" title="View profile: Sheppy">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="Sheppy" data-src="https://secure.gravatar.com/avatar/945076feb88f2d7003891ffbf06f32bf?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">Sheppy</noscript></a>
-                </li>
-
-                <li class="shown">
-                <a href="/en-US/profiles/myuller" title="View profile: myuller">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="myuller" data-src="https://secure.gravatar.com/avatar/b6278740a510cff48758ad9f4b10bf48?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">myuller</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/rk17" title="View profile: rk17">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="rk17" data-src="https://secure.gravatar.com/avatar/797774a673cefaea1874d302790ec132?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">rk17</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/louuis" title="View profile: louuis">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="louuis" data-src="https://secure.gravatar.com/avatar/f71f6ff4b1cb760a924097f5f7e7d423?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">louuis</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/George8211" title="View profile: George8211">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="George8211" data-src="https://secure.gravatar.com/avatar/7d0b4cc96c77b96db4bfb94eb04de29e?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">George8211</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/estelle" title="View profile: estelle">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="estelle" data-src="https://secure.gravatar.com/avatar/8e75de08afdc1e0fe9333e758d3c7249?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">estelle</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/klez" title="View profile: klez">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="klez" data-src="https://secure.gravatar.com/avatar/8f12f2e8aea4579fb6cb12c6a197a797?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">klez</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/kscarfone" title="View profile: kscarfone">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="kscarfone" data-src="https://secure.gravatar.com/avatar/89c1e54a9703125168e40d22316d2b49?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">kscarfone</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/Shokr" title="View profile: Shokr">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="Shokr" data-src="https://secure.gravatar.com/avatar/1198883abef2a48e2d5c20fce1538570?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">Shokr</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/Techsin" title="View profile: Techsin">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="Techsin" data-src="https://secure.gravatar.com/avatar/8afd88ea8f653f95e2588769c2cfab6a?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">Techsin</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/haboqueferus" title="View profile: haboqueferus">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="haboqueferus" data-src="https://secure.gravatar.com/avatar/87d659da4bb92cd4d843829b58b3e6b6?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">haboqueferus</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/evilpie" title="View profile: evilpie">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="evilpie" data-src="https://secure.gravatar.com/avatar/6bb31f7207fc068158047b9c8ad4592d?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">evilpie</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/Srggamer" title="View profile: Srggamer">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="Srggamer" data-src="https://secure.gravatar.com/avatar/3a05e8d3c8ff845144105ac0c6d4bef5?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">Srggamer</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/lmorchard" title="View profile: lmorchard">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="lmorchard" data-src="https://secure.gravatar.com/avatar/b45c48fc9e05922e2f368a9d7d7d8de1?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">lmorchard</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/shirayuki" title="View profile: shirayuki">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="shirayuki" data-src="https://secure.gravatar.com/avatar/fc7751ef5d1748227b2dd00956c77986?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">shirayuki</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/jonathan.camenisch" title="View profile: jonathan.camenisch">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="jonathan.camenisch" data-src="https://secure.gravatar.com/avatar/534c781a2786a86d3459e35b04a29e90?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">jonathan.camenisch</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/tregagnon" title="View profile: tregagnon">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="tregagnon" data-src="https://secure.gravatar.com/avatar/8431892ef37f88fe820096de721c00ba?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">tregagnon</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/Markus%20Prokott" title="View profile: Markus Prokott">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="Markus Prokott" data-src="https://secure.gravatar.com/avatar/1497d3b4beaa51767a0ffed2c7834c19?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">Markus Prokott</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/McGurk" title="View profile: McGurk">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="McGurk" data-src="https://secure.gravatar.com/avatar/dcf5220f84cecf5b4eec14f0c43a589a?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">McGurk</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/masondesu" title="View profile: masondesu">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="masondesu" data-src="https://secure.gravatar.com/avatar/091bc95204caaf52b0d299bd9ac59540?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">masondesu</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/hobophobe" title="View profile: hobophobe">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="hobophobe" data-src="https://secure.gravatar.com/avatar/4773ab39b745afa4bdb2e556cbc9dd87?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">hobophobe</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/fscholz" title="View profile: fscholz">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="fscholz" data-src="https://secure.gravatar.com/avatar/e24391c9174352988d819a9b9ea77c9e?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">fscholz</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/thatryan" title="View profile: thatryan">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="thatryan" data-src="https://secure.gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">thatryan</noscript></a>
-                </li>
-
-                <li class="hidden">
-                <a href="/en-US/profiles/garann" title="View profile: garann">
-                <noscript data-width="34" data-height="34" data-class="avatar" data-alt="garann" data-src="https://secure.gravatar.com/avatar/76f795cabbf80024b1024517c67f0bcf?s=34&amp;r=pg&amp;d=https%3A%2F%2Fdeveloper.cdn.mozilla.net%2Fmedia%2Fimg%2Favatar.png">garann</noscript></a>
-                </li>
-
-            </ul>
-        </div>
+      <div class="center clear">
 
 
-        <h1>HTML attribute reference</h1>
-
-      </div>
-
-
+    <div class="wiki-main-content" id="document-main"><div class="center">
       <!-- start the main content container -->
-        <div id="wiki-column-container" class="wiki-right-present wiki-left-closed wiki-left-none">
+        <div id="wiki-column-container" class="wiki-left-present">
 
           <!-- content row with three strips -->
           <div class="column-container column-container-reverse">
 
-
-              <!-- TOC, approvals, etc -->
-              <div class="column-strip wiki-column" id="wiki-right">
-
-              <!-- table of contents -->
-              <div id="toc" class="toc toggleable">
-                <a href="#toc" class="title toggler" data-open-icon="icon-plus" data-closed-icon="icon-minus">In This Article<i></i></a>
-                <ol class="toggle-container">
-                  <li><a href="#Attribute_list" rel="internal">Attribute list</a><li><a href="#Content_versus_IDL_attributes" rel="internal">Content versus IDL attributes</a><li><a href="#See_also" rel="internal">See also</a>
-                </ol>
-              </div>
-
-              </div>
-
-
-
-
-
-
-
             <!-- center: main article content -->
             <div id="wiki-content" class="column-main wiki-column text-content">
-
 
 
 
@@ -654,7 +536,9 @@
               <article id="wikiArticle">
 
 
-                    <p>Elements in HTML have <strong>attributes</strong>; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.</p>
+                    <div></div>
+
+<p>Elements in HTML have <strong>attributes</strong>; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.</p>
 
 <h2 id="Attribute_list">Attribute list</h2>
 
@@ -669,84 +553,96 @@
  <tbody>
   <tr>
    <td><code>accept</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls to submit information to a web server."><code>&lt;form&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls for submitting information to a web server."><code>&lt;form&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a></td>
    <td>List of types the server accepts, typically a file type.</td>
   </tr>
   <tr>
    <td><code>accept-charset</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls to submit information to a web server."><code>&lt;form&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls for submitting information to a web server."><code>&lt;form&gt;</code></a></td>
    <td>List of supported charsets.</td>
   </tr>
   <tr>
-   <td><code>accesskey</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Global_attributes/accesskey">accesskey</a></code></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Defines a keyboard shortcut to activate or add focus to the element.</td>
   </tr>
   <tr>
    <td><code>action</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls to submit information to a web server."><code>&lt;form&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls for submitting information to a web server."><code>&lt;form&gt;</code></a></td>
    <td>The URI of a program that processes the information submitted via the form.</td>
   </tr>
   <tr>
    <td><code>align</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/applet" title="The HTML Applet Element (&lt;applet>) identifies the inclusion of a Java applet."><code>&lt;applet&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/caption" title="The HTML &lt;caption> Element (or HTML Table Caption Element) represents the title of a table. Though it is always the first descendant of a &lt;table>, its styling, using CSS, may place it elsewhere, relative to the table."><code>&lt;caption&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/col" title="The HTML Table Column Element (&lt;col>) defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a &lt;colgroup> element."><code>&lt;col&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/colgroup" title="The HTML Table Column Group Element (&lt;colgroup>) defines a group of columns within a table."><code>&lt;colgroup&gt;</code></a>,  <a href="/en-US/docs/Web/HTML/Element/hr" title="The HTML &lt;hr> element represents a thematic break between paragraph-level elements (for example, a change of scene in a story, or a shift of topic with a section). In previous versions of HTML, it represented a horizontal rule. It may still be displayed as a horizontal rule in visual browsers, but is now defined in semantic terms, rather than presentational terms."><code>&lt;hr&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame Element (&lt;iframe>) represents a nested browsing context, effectively embedding another HTML page into the current page. In HTML 4.01, a document may contain a head and a body or a head and a frame-set, but not both a body and a frame-set. However, an &lt;iframe> can be used within a normal document body. Each browsing context has its own session history and active document. The browsing context that contains the embedded content is called the parent browsing context. The top-level browsing context (which has no parent) is typically the browser window."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element represents an image in the document."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/table" title="The HTML Table Element (&lt;table>) represents tabular data: information expressed via two dimensions or more."><code>&lt;table&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/tbody" title="The HTML Table Body Element (&lt;tbody>) defines one or more &lt;tr> element data-rows to be the body of its parent &lt;table> element (as long as no &lt;tr> elements are immediate children of that table element.)  In conjunction with a preceding &lt;thead> and/or &lt;tfoot> element, &lt;tbody> provides additional semantic information for devices such as printers and displays. Of the parent table's child elements, &lt;tbody> represents the content which, when longer than a page, will most likely differ for each page printed; while the content of &lt;thead> and &lt;tfoot> will be the same or similar for each page printed. For displays, &lt;tbody> will enable separate scrolling of the &lt;thead>, &lt;tfoot>, and &lt;caption> elements of the same parent &lt;table> element.  Note that unlike the &lt;thead>, &lt;tfoot>, and &lt;caption> elements however, multiple &lt;tbody> elements are permitted (if consecutive), allowing the data-rows in long tables to be divided into different sections, each separately formatted as needed."><code>&lt;tbody&gt;</code></a>,  <a href="/en-US/docs/Web/HTML/Element/td" title="The Table cell HTML element (&lt;td>) defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a>,  <a href="/en-US/docs/Web/HTML/Element/tfoot" title="The HTML Table Foot Element (&lt;tfoot>) defines a set of rows summarizing the columns of the table."><code>&lt;tfoot&gt;</code></a> , <a href="/en-US/docs/Web/HTML/Element/th" title="The HTML element table header cell &lt;th> defines a cell as a header for a group of cells of a table. The group of cells that the header refers to is defined by the scope and headers attribute."><code>&lt;th&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/thead" title="The HTML Table Head Element (&lt;thead>) defines a set of rows defining the head of the columns of the table."><code>&lt;thead&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/tr" title="The HTML element table row &lt;tr> defines a row of cells in a table. Those can be a mix of &lt;td> and &lt;th> elements."><code>&lt;tr&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/applet" title="The obsolete HTML Applet Element (&lt;applet>) embeds a Java applet into the document; this element has been deprecated in favor of &lt;object>."><code>&lt;applet&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/caption" title="The HTML Table Caption element (&lt;caption>) specifies the caption (or title) of a table, and if used is always the first child of a &lt;table>."><code>&lt;caption&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/col" title="The HTML &lt;col> element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a &lt;colgroup> element."><code>&lt;col&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/colgroup" title="The HTML &lt;colgroup> element defines a group of columns within a table."><code>&lt;colgroup&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/hr" title="The HTML &lt;hr> element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section."><code>&lt;hr&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/table" title="The HTML &lt;table> element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data."><code>&lt;table&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/tbody" title="The HTML Table Body element (&lt;tbody>) encapsulates a set of table rows (&lt;tr> elements), indicating that they comprise the body of the table (&lt;table>)."><code>&lt;tbody&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/td" title="The HTML &lt;td> element defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/tfoot" title="The HTML &lt;tfoot> element defines a set of rows summarizing the columns of the table."><code>&lt;tfoot&gt;</code></a> , <a href="/en-US/docs/Web/HTML/Element/th" title="The HTML &lt;th> element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes."><code>&lt;th&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/thead" title="The HTML &lt;thead> element defines a set of rows defining the head of the columns of the table."><code>&lt;thead&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/tr" title="The HTML &lt;tr> element defines a row of cells in a table. The row's cells can then be established using a mix of &lt;td> (data cell) and &lt;th> (header cell) elements.The HTML &lt;tr> element specifies that the markup contained inside the &lt;tr> block comprises one row of a table, inside which the &lt;th> and &lt;td> elements create header and data cells, respectively, within the row."><code>&lt;tr&gt;</code></a></td>
    <td>Specifies the horizontal alignment of the element.</td>
   </tr>
   <tr>
+   <td><code>allow</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a></td>
+   <td>Specifies a feature-policy for the iframe.</td>
+  </tr>
+  <tr>
    <td><code>alt</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/applet" title="The HTML Applet Element (&lt;applet>) identifies the inclusion of a Java applet."><code>&lt;applet&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element represents an image in the document."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/applet" title="The obsolete HTML Applet Element (&lt;applet>) embeds a Java applet into the document; this element has been deprecated in favor of &lt;object>."><code>&lt;applet&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a></td>
    <td>Alternative text in case an image can't be displayed.</td>
   </tr>
   <tr>
    <td><code>async</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/script" title="The HTML Script Element (&lt;script>) is used to embed or reference an executable script within an HTML or XHTML document."><code>&lt;script&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/script" title="The HTML &lt;script> element is used to embed or reference executable code; this is typically used to embed or refer to JavaScript code."><code>&lt;script&gt;</code></a></td>
    <td>Indicates that the script should be executed asynchronously.</td>
   </tr>
   <tr>
-   <td><code>autocomplete</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls to submit information to a web server."><code>&lt;form&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a></td>
+   <td><code><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize">autocapitalize</a></code></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
+   <td>Controls whether and how text input is automatically capitalized as it is entered/edited by the user.</td>
+  </tr>
+  <tr>
+   <td><code><a href="/en-US/docs/Web/HTML/Attributes/autocomplete">autocomplete</a></code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls for submitting information to a web server."><code>&lt;form&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML &lt;select> element represents a control that provides a menu of options"><code>&lt;select&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td>Indicates whether controls in this form can by default have their values automatically completed by the browser.</td>
   </tr>
   <tr>
    <td><code>autofocus</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> Element represents a clickable button."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/keygen" title="The HTML &lt;keygen> element exists to facilitate generation of key material, and submission of the public key as part of an HTML form. This mechanism is designed for use with Web-based certificate management systems. It is expected that the &lt;keygen> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate."><code>&lt;keygen&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML select (&lt;select>) element represents a control that presents a menu of options. The options within the menu are represented by &lt;option> elements, which can be grouped by &lt;optgroup> elements. Options can be pre-selected for the user."><code>&lt;select&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/keygen" title="The HTML &lt;keygen> element exists to facilitate generation of key material, and submission of the public key as part of an HTML form. This mechanism is designed for use with Web-based certificate management systems. It is expected that the &lt;keygen> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate."><code>&lt;keygen&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML &lt;select> element represents a control that provides a menu of options"><code>&lt;select&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td>The element should be automatically focused after the page loaded.</td>
   </tr>
   <tr>
    <td><code>autoplay</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element; the browser will choose the most suitable one."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="Editorial review completed."><code>&lt;video&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></td>
    <td>The audio or video should play as soon as possible.</td>
   </tr>
   <tr>
-   <td><code>autosave</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a></td>
-   <td>Previous values should persist dropdowns of selectable values across page loads.</td>
+   <td><code>background</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/body" title="The HTML &lt;body> Element represents the content of an HTML document. There can be only one &lt;body> element in a document."><code>&lt;body&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/table" title="The HTML &lt;table> element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data."><code>&lt;table&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/td" title="The HTML &lt;td> element defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/th" title="The HTML &lt;th> element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes."><code>&lt;th&gt;</code></a></td>
+   <td>Specifies the URL of an image file.
+    <div class="note"><strong>Note:</strong> Although browsers and email clients may still support this attribute, it is obsolete. Use CSS <a href="/en-US/docs/Web/CSS/background-image" title="The background-image CSS property sets one or more background images on an element."><code>background-image</code></a> instead.</div>
+   </td>
   </tr>
   <tr>
    <td><code>bgcolor</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/body" title="The HTML &lt;body> Element represents the content of an HTML document. There can be only one &lt;body> element in a document."><code>&lt;body&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/col" title="The HTML Table Column Element (&lt;col>) defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a &lt;colgroup> element."><code>&lt;col&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/colgroup" title="The HTML Table Column Group Element (&lt;colgroup>) defines a group of columns within a table."><code>&lt;colgroup&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/marquee" title="The HTML &lt;marquee> element is used to insert a scrolling area of text."><code>&lt;marquee&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/table" title="The HTML Table Element (&lt;table>) represents tabular data: information expressed via two dimensions or more."><code>&lt;table&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/tbody" title="The HTML Table Body Element (&lt;tbody>) defines one or more &lt;tr> element data-rows to be the body of its parent &lt;table> element (as long as no &lt;tr> elements are immediate children of that table element.)  In conjunction with a preceding &lt;thead> and/or &lt;tfoot> element, &lt;tbody> provides additional semantic information for devices such as printers and displays. Of the parent table's child elements, &lt;tbody> represents the content which, when longer than a page, will most likely differ for each page printed; while the content of &lt;thead> and &lt;tfoot> will be the same or similar for each page printed. For displays, &lt;tbody> will enable separate scrolling of the &lt;thead>, &lt;tfoot>, and &lt;caption> elements of the same parent &lt;table> element.  Note that unlike the &lt;thead>, &lt;tfoot>, and &lt;caption> elements however, multiple &lt;tbody> elements are permitted (if consecutive), allowing the data-rows in long tables to be divided into different sections, each separately formatted as needed."><code>&lt;tbody&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/tfoot" title="The HTML Table Foot Element (&lt;tfoot>) defines a set of rows summarizing the columns of the table."><code>&lt;tfoot&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/td" title="The Table cell HTML element (&lt;td>) defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/th" title="The HTML element table header cell &lt;th> defines a cell as a header for a group of cells of a table. The group of cells that the header refers to is defined by the scope and headers attribute."><code>&lt;th&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/tr" title="The HTML element table row &lt;tr> defines a row of cells in a table. Those can be a mix of &lt;td> and &lt;th> elements."><code>&lt;tr&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/body" title="The HTML &lt;body> Element represents the content of an HTML document. There can be only one &lt;body> element in a document."><code>&lt;body&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/col" title="The HTML &lt;col> element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a &lt;colgroup> element."><code>&lt;col&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/colgroup" title="The HTML &lt;colgroup> element defines a group of columns within a table."><code>&lt;colgroup&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/marquee" title="The HTML &lt;marquee> element is used to insert a scrolling area of text. You can control what happens when the text reaches the edges of its content area using its attributes."><code>&lt;marquee&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/table" title="The HTML &lt;table> element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data."><code>&lt;table&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/tbody" title="The HTML Table Body element (&lt;tbody>) encapsulates a set of table rows (&lt;tr> elements), indicating that they comprise the body of the table (&lt;table>)."><code>&lt;tbody&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/tfoot" title="The HTML &lt;tfoot> element defines a set of rows summarizing the columns of the table."><code>&lt;tfoot&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/td" title="The HTML &lt;td> element defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/th" title="The HTML &lt;th> element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes."><code>&lt;th&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/tr" title="The HTML &lt;tr> element defines a row of cells in a table. The row's cells can then be established using a mix of &lt;td> (data cell) and &lt;th> (header cell) elements.The HTML &lt;tr> element specifies that the markup contained inside the &lt;tr> block comprises one row of a table, inside which the &lt;th> and &lt;td> elements create header and data cells, respectively, within the row."><code>&lt;tr&gt;</code></a></td>
    <td>
     <p>Background color of the element.</p>
 
     <div class="note">
-    <p><strong>Note:</strong> This is a legacy attribute. Please use the CSS <a href="/en-US/docs/Web/CSS/background-color" title="The background-color CSS property sets the background color of an element, either through a color value or the keyword transparent."><code>background-color</code></a> property instead.</p>
+    <p><strong>Note:</strong> This is a legacy attribute. Please use the CSS <a href="/en-US/docs/Web/CSS/background-color" title="The background-color CSS property sets the background color of an element."><code>background-color</code></a> property instead.</p>
     </div>
    </td>
   </tr>
   <tr>
    <td><code>border</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element represents an image in the document."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML Embedded Object Element (&lt;object>) represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/table" title="The HTML Table Element (&lt;table>) represents tabular data: information expressed via two dimensions or more."><code>&lt;table&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML &lt;object> element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/table" title="The HTML &lt;table> element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data."><code>&lt;table&gt;</code></a></td>
    <td>
     <p>The border width.</p>
 
     <div class="note">
-    <p><strong>Note:</strong> This is a legacy attribute. Please use the CSS <a href="/en-US/docs/Web/CSS/border" title="The border CSS property is a shorthand property for setting the individual border property values in a single place in the style sheet. border can be used to set the values for one or more of: border-width, border-style, border-color."><code>border</code></a> property instead.</p>
+    <p><strong>Note:</strong> This is a legacy attribute. Please use the CSS <a href="/en-US/docs/Web/CSS/border" title="The border shorthand CSS property sets an element's border."><code>border</code></a> property instead.</p>
     </div>
    </td>
   </tr>
   <tr>
    <td><code>buffered</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element; the browser will choose the most suitable one."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="Editorial review completed."><code>&lt;video&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></td>
    <td>Contains the time range of already buffered media.</td>
   </tr>
   <tr>
@@ -756,73 +652,73 @@
   </tr>
   <tr>
    <td><code>charset</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/meta" title="The HTML &lt;meta> element represents any metadata information that cannot be represented by one of the other HTML meta-related elements (&lt;base>, &lt;link>, &lt;script>, &lt;style> or &lt;title>)."><code>&lt;meta&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/script" title="The HTML Script Element (&lt;script>) is used to embed or reference an executable script within an HTML or XHTML document."><code>&lt;script&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/meta" title="The HTML &lt;meta> element represents metadata that cannot be represented by other HTML meta-related elements, like &lt;base>, &lt;link>, &lt;script>, &lt;style> or &lt;title>."><code>&lt;meta&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/script" title="The HTML &lt;script> element is used to embed or reference executable code; this is typically used to embed or refer to JavaScript code."><code>&lt;script&gt;</code></a></td>
    <td>Declares the character encoding of the page or script.</td>
   </tr>
   <tr>
    <td><code>checked</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/command" title="The command element represents a command which the user can invoke."><code>&lt;command&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/command" title="The HTML Command element (&lt;command>) represents a command which the user can invoke. Commands are often used as part of a context menu or toolbar."><code>&lt;command&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a></td>
    <td>Indicates whether the element should be checked on page load.</td>
   </tr>
   <tr>
    <td><code>cite</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/blockquote" title="The HTML &lt;blockquote> Element (or HTML Block Quotation Element) indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the &lt;cite> element."><code>&lt;blockquote&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/del" title="The HTML Deleted Text Element (&lt;del>) represents a range of text that has been deleted from a document. This element is often (but need not be) rendered with strike-through text."><code>&lt;del&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/ins" title="The HTML &lt;ins> Element (or HTML Inserted Text) HTML represents a range of text that has been added to a document."><code>&lt;ins&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/q" title="The HTML Quote Element (&lt;q>) indicates that the enclosed text is a short inline quotation. This element is intended for short quotations that don't require paragraph breaks; for long quotations use &lt;blockquote> element."><code>&lt;q&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/blockquote" title="The HTML &lt;blockquote> Element (or HTML Block Quotation Element) indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the &lt;cite> element."><code>&lt;blockquote&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/del" title="The HTML &lt;del> element represents a range of text that has been deleted from a document."><code>&lt;del&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/ins" title="The HTML &lt;ins> element represents a range of text that has been added to a document."><code>&lt;ins&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/q" title="The HTML &lt;q> element  indicates that the enclosed text is a short inline quotation. Most modern browsers implement this by surrounding the text in quotation marks. "><code>&lt;q&gt;</code></a></td>
    <td>Contains a URI which points to the source of the quote or change.</td>
   </tr>
   <tr>
    <td><code>class</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Often used with CSS to style elements with common properties.</td>
   </tr>
   <tr>
    <td><code>code</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/applet" title="The HTML Applet Element (&lt;applet>) identifies the inclusion of a Java applet."><code>&lt;applet&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/applet" title="The obsolete HTML Applet Element (&lt;applet>) embeds a Java applet into the document; this element has been deprecated in favor of &lt;object>."><code>&lt;applet&gt;</code></a></td>
    <td>Specifies the URL of the applet's class file to be loaded and executed.</td>
   </tr>
   <tr>
    <td><code>codebase</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/applet" title="The HTML Applet Element (&lt;applet>) identifies the inclusion of a Java applet."><code>&lt;applet&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/applet" title="The obsolete HTML Applet Element (&lt;applet>) embeds a Java applet into the document; this element has been deprecated in favor of &lt;object>."><code>&lt;applet&gt;</code></a></td>
    <td>This attribute gives the absolute or relative URL of the directory where applets' .class files referenced by the code attribute are stored.</td>
   </tr>
   <tr>
    <td><code>color</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/basefont" title="The HTML basefont element (&lt;basefont>) establishes a default font size for a document. Font size then can be varied relative to the base font size using the &lt;font> element."><code>&lt;basefont&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/font" title="The HTML Font Element (&lt;font>) defines the font size, color and face for its content."><code>&lt;font&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/hr" title="The HTML &lt;hr> element represents a thematic break between paragraph-level elements (for example, a change of scene in a story, or a shift of topic with a section). In previous versions of HTML, it represented a horizontal rule. It may still be displayed as a horizontal rule in visual browsers, but is now defined in semantic terms, rather than presentational terms."><code>&lt;hr&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/basefont" title="The obsolete HTML Base Font element (&lt;basefont>) sets a default font face, size, and color for the other elements which are descended from its parent element."><code>&lt;basefont&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/font" title="The HTML Font Element (&lt;font>) defines the font size, color and face for its content."><code>&lt;font&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/hr" title="The HTML &lt;hr> element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section."><code>&lt;hr&gt;</code></a></td>
    <td>
     <p>This attribute sets the text color using either a named color or a color specified in the hexadecimal #RRGGBB format.</p>
 
     <div class="note">
-    <p><strong>Note:</strong> This is a legacy attribute. Please use the CSS <a href="/en-US/docs/Web/CSS/color" title="The color property sets the foreground color of an element's text content, and its decorations. It doesn't affect any other characteristic of the element; it should really be called text-color and would have been named so, save for historical reasons and its appearance in CSS Level 1."><code>color</code></a> property instead.</p>
+    <p><strong>Note:</strong> This is a legacy attribute. Please use the CSS <a href="/en-US/docs/Web/CSS/color" title="The color CSS property sets the foreground color value of an element's text and text decorations, and sets the currentcolor value."><code>color</code></a> property instead.</p>
     </div>
    </td>
   </tr>
   <tr>
    <td><code>cols</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td>Defines the number of columns in a textarea.</td>
   </tr>
   <tr>
    <td><code>colspan</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/td" title="The Table cell HTML element (&lt;td>) defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/th" title="The HTML element table header cell &lt;th> defines a cell as a header for a group of cells of a table. The group of cells that the header refers to is defined by the scope and headers attribute."><code>&lt;th&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/td" title="The HTML &lt;td> element defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/th" title="The HTML &lt;th> element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes."><code>&lt;th&gt;</code></a></td>
    <td>The colspan attribute defines the number of columns a cell should span.</td>
   </tr>
   <tr>
    <td><code>content</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/meta" title="The HTML &lt;meta> element represents any metadata information that cannot be represented by one of the other HTML meta-related elements (&lt;base>, &lt;link>, &lt;script>, &lt;style> or &lt;title>)."><code>&lt;meta&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/meta" title="The HTML &lt;meta> element represents metadata that cannot be represented by other HTML meta-related elements, like &lt;base>, &lt;link>, &lt;script>, &lt;style> or &lt;title>."><code>&lt;meta&gt;</code></a></td>
    <td>A value associated with <code>http-equiv</code> or <code>name</code> depending on the context.</td>
   </tr>
   <tr>
-   <td><code>contenteditable</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><code><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable">contenteditable</a></code></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Indicates whether the element's content is editable.</td>
   </tr>
   <tr>
    <td><code>contextmenu</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Defines the ID of a <a href="/en-US/docs/Web/HTML/Element/menu" title="The HTML &lt;menu> element represents a group of commands that a user can perform or activate. This includes both list menus, which might appear across the top of a screen, as well as context menus, such as those that might appear underneath a button after it has been clicked."><code>&lt;menu&gt;</code></a> element which will serve as the element's context menu.</td>
   </tr>
   <tr>
    <td><code>controls</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element; the browser will choose the most suitable one."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="Editorial review completed."><code>&lt;video&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></td>
    <td>Indicates whether the browser should show playback controls to the user.</td>
   </tr>
   <tr>
@@ -831,139 +727,201 @@
    <td>A set of values specifying the coordinates of the hot-spot region.</td>
   </tr>
   <tr>
+   <td><code><a href="/docs/Web/HTML/CORS_settings_attributes">crossorigin</a></code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/link" title='The HTML External Resource Link element (&lt;link>) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and mobile home screen/app icons) among other things.'><code>&lt;link&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/script" title="The HTML &lt;script> element is used to embed or reference executable code; this is typically used to embed or refer to JavaScript code."><code>&lt;script&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></td>
+   <td>How the element handles cross-origin requests</td>
+  </tr>
+  <tr>
+   <td><code><a href="/docs/Web/API/HTMLiframeElement/csp">csp</a></code> <span title="This is an experimental API that should not be used in production code."><i class="icon-beaker"> </i></span></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a></td>
+   <td>Specifies the Content Security Policy that an embedded document must agree to enforce upon itself.</td>
+  </tr>
+  <tr>
    <td><code>data</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/object" title="The HTML Embedded Object Element (&lt;object>) represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/object" title="The HTML &lt;object> element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a></td>
    <td>Specifies the URL of the resource.</td>
   </tr>
   <tr>
-   <td><code>data-*</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Global_attributes/data-*">data-*</a></code></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Lets you attach custom attributes to an HTML element.</td>
   </tr>
   <tr>
    <td><code>datetime</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/del" title="The HTML Deleted Text Element (&lt;del>) represents a range of text that has been deleted from a document. This element is often (but need not be) rendered with strike-through text."><code>&lt;del&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/ins" title="The HTML &lt;ins> Element (or HTML Inserted Text) HTML represents a range of text that has been added to a document."><code>&lt;ins&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/time" title="Technical review completed."><code>&lt;time&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/del" title="The HTML &lt;del> element represents a range of text that has been deleted from a document."><code>&lt;del&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/ins" title="The HTML &lt;ins> element represents a range of text that has been added to a document."><code>&lt;ins&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/time" title="The HTML &lt;time> element represents a specific period in time."><code>&lt;time&gt;</code></a></td>
    <td>Indicates the date and time associated with the element.</td>
   </tr>
   <tr>
+   <td><code>decoding</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a></td>
+   <td>Indicates the preferred method to decode the image.</td>
+  </tr>
+  <tr>
    <td><code>default</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/track" title="The HTML &lt;track> element is used as a child of the media elements—&lt;audio> and &lt;video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks."><code>&lt;track&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/track" title="The HTML &lt;track> element is used as a child of the media elements &lt;audio> and &lt;video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks or Timed Text Markup Language (TTML)."><code>&lt;track&gt;</code></a></td>
    <td>Indicates that the track should be enabled unless the user's preferences indicate something different.</td>
   </tr>
   <tr>
    <td><code>defer</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/script" title="The HTML Script Element (&lt;script>) is used to embed or reference an executable script within an HTML or XHTML document."><code>&lt;script&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/script" title="The HTML &lt;script> element is used to embed or reference executable code; this is typically used to embed or refer to JavaScript code."><code>&lt;script&gt;</code></a></td>
    <td>Indicates that the script should be executed after the page has been parsed.</td>
   </tr>
   <tr>
-   <td><code>dir</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><code><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir">dir</a></code></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)</td>
   </tr>
   <tr>
    <td><code>dirname</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>disabled</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> Element represents a clickable button."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/command" title="The command element represents a command which the user can invoke."><code>&lt;command&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/fieldset" title="The HTML &lt;fieldset> element is used to group several controls as well as labels (&lt;label>) within a web form."><code>&lt;fieldset&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/keygen" title="The HTML &lt;keygen> element exists to facilitate generation of key material, and submission of the public key as part of an HTML form. This mechanism is designed for use with Web-based certificate management systems. It is expected that the &lt;keygen> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate."><code>&lt;keygen&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/optgroup" title="In a Web form, the HTML &lt;optgroup> element  creates a grouping of options within a &lt;select> element."><code>&lt;optgroup&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/option" title="In a Web form, the HTML &lt;option> element is used to create a control representing an item within a &lt;select>, an &lt;optgroup> or a &lt;datalist> HTML5 element."><code>&lt;option&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML select (&lt;select>) element represents a control that presents a menu of options. The options within the menu are represented by &lt;option> elements, which can be grouped by &lt;optgroup> elements. Options can be pre-selected for the user."><code>&lt;select&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/command" title="The HTML Command element (&lt;command>) represents a command which the user can invoke. Commands are often used as part of a context menu or toolbar."><code>&lt;command&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/fieldset" title="The HTML &lt;fieldset> element is used to group several controls as well as labels (&lt;label>) within a web form."><code>&lt;fieldset&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/keygen" title="The HTML &lt;keygen> element exists to facilitate generation of key material, and submission of the public key as part of an HTML form. This mechanism is designed for use with Web-based certificate management systems. It is expected that the &lt;keygen> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate."><code>&lt;keygen&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/optgroup" title="The HTML &lt;optgroup> element creates a grouping of options within a &lt;select> element."><code>&lt;optgroup&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/option" title="The HTML &lt;option> element is used to define an item contained in a &lt;select>, an &lt;optgroup>, or a &lt;datalist> element. As such, &lt;option> can represent menu items in popups and other lists of items in an HTML document."><code>&lt;option&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML &lt;select> element represents a control that provides a menu of options"><code>&lt;select&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td>Indicates whether the user can interact with the element.</td>
   </tr>
   <tr>
    <td><code>download</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML Anchor Element (&lt;a>) defines a hyperlink to a location on the same page or any other page on the Web. It can also be used (in an obsolete way) to create an anchor point—a destination for hyperlinks within the content of a page, so that links aren't limited to connecting simply to the top of a page."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML &lt;a> element (or anchor element), along with it's href attribute, creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a></td>
    <td>Indicates that the hyperlink is to be used for downloading a resource.</td>
   </tr>
   <tr>
    <td><code>draggable</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Defines whether the element can be dragged.</td>
   </tr>
   <tr>
    <td><code>dropzone</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Indicates that the element accept the dropping of content on it.</td>
   </tr>
   <tr>
    <td><code>enctype</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls to submit information to a web server."><code>&lt;form&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls for submitting information to a web server."><code>&lt;form&gt;</code></a></td>
    <td>Defines the content type of the form date when the <code>method</code> is POST.</td>
   </tr>
   <tr>
+   <td><code>enterkeyhint</code> <span title="This is an experimental API that should not be used in production code."><i class="icon-beaker"> </i></span></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a>, <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable"><code>contenteditable</code></a></td>
+   <td>The <a class="external" href="https://html.spec.whatwg.org/dev/interaction.html#input-modalities:-the-enterkeyhint-attribute" rel="noopener"><code>enterkeyhint</code></a> specifies what action label (or icon) to present for the enter key on virtual keyboards. The attribute can be used with form controls (such as the value of <code>textarea</code> elements), or in elements in an editing host (e.g., using <code>contenteditable</code> attribute).</td>
+  </tr>
+  <tr>
    <td><code>for</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/label" title="The HTML Label Element (&lt;label>) represents a caption for an item in a user interface. It can be associated with a control either by placing the control element inside the &lt;label> element, or by using the for attribute. Such a control is called the labeled control of the label element. One input can be associated with multiple labels."><code>&lt;label&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/output" title="The HTML &lt;output> element represents the result of a calculation or user action."><code>&lt;output&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/label" title="The HTML &lt;label> element represents a caption for an item in a user interface."><code>&lt;label&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/output" title="The HTML Output element (&lt;output>) is a container element into which a site or app can inject the results of a calculation or the outcome of a user action."><code>&lt;output&gt;</code></a></td>
    <td>Describes elements which belongs to this one.</td>
   </tr>
   <tr>
    <td><code>form</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> Element represents a clickable button."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/fieldset" title="The HTML &lt;fieldset> element is used to group several controls as well as labels (&lt;label>) within a web form."><code>&lt;fieldset&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/keygen" title="The HTML &lt;keygen> element exists to facilitate generation of key material, and submission of the public key as part of an HTML form. This mechanism is designed for use with Web-based certificate management systems. It is expected that the &lt;keygen> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate."><code>&lt;keygen&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/label" title="The HTML Label Element (&lt;label>) represents a caption for an item in a user interface. It can be associated with a control either by placing the control element inside the &lt;label> element, or by using the for attribute. Such a control is called the labeled control of the label element. One input can be associated with multiple labels."><code>&lt;label&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> Element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML Embedded Object Element (&lt;object>) represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/output" title="The HTML &lt;output> element represents the result of a calculation or user action."><code>&lt;output&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/progress" title="The HTML &lt;progress> Element is used to view the completion progress of a task. While the specifics of how it's displayed is left up to the browser developer, it's typically displayed as a progress bar. Javascript can be used to manipulate the value of progress bar."><code>&lt;progress&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML select (&lt;select>) element represents a control that presents a menu of options. The options within the menu are represented by &lt;option> elements, which can be grouped by &lt;optgroup> elements. Options can be pre-selected for the user."><code>&lt;select&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/fieldset" title="The HTML &lt;fieldset> element is used to group several controls as well as labels (&lt;label>) within a web form."><code>&lt;fieldset&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/keygen" title="The HTML &lt;keygen> element exists to facilitate generation of key material, and submission of the public key as part of an HTML form. This mechanism is designed for use with Web-based certificate management systems. It is expected that the &lt;keygen> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate."><code>&lt;keygen&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/label" title="The HTML &lt;label> element represents a caption for an item in a user interface."><code>&lt;label&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML &lt;object> element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/output" title="The HTML Output element (&lt;output>) is a container element into which a site or app can inject the results of a calculation or the outcome of a user action."><code>&lt;output&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/progress" title="The HTML &lt;progress> element displays an indicator showing the completion progress of a task, typically displayed as a progress bar."><code>&lt;progress&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML &lt;select> element represents a control that provides a menu of options"><code>&lt;select&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td>Indicates the form that is the owner of the element.</td>
   </tr>
   <tr>
    <td><code>formaction</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> Element represents a clickable button."><code>&lt;button&gt;</code></a></td>
-   <td>Indicates the action of the element, overriding the action defined in the <a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls to submit information to a web server."><code>&lt;form&gt;</code></a>.</td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a></td>
+   <td>Indicates the action of the element, overriding the action defined in the <a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls for submitting information to a web server."><code>&lt;form&gt;</code></a>.</td>
+  </tr>
+  <tr>
+   <td><code>formenctype</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a></td>
+   <td>If the button/input is a submit button (<code>type="submit"</code>), this attribute sets the encoding type to use during form submission. If this attribute is specified, it overrides the <code>enctype</code> attribute of the button's <a href="/en-US/docs/Web/HTML/Element/form">form</a> owner.</td>
+  </tr>
+  <tr>
+   <td><code>formmethod</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a></td>
+   <td>If the button/input is a submit button (<code>type="submit"</code>), this attribute sets the submission method to use during form submission (<code>GET</code>, <code>POST</code>, etc.). If this attribute is specified, it overrides the <code>method</code> attribute of the button's <a href="/en-US/docs/Web/HTML/Element/form">form</a> owner.</td>
+  </tr>
+  <tr>
+   <td><code>formnovalidate</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a></td>
+   <td>If the button/input is a submit button (<code>type="submit"</code>), this boolean attribute specifies that the form is not to be validated when it is submitted. If this attribute is specified, it overrides the <code>novalidate</code> attribute of the button's <a href="/en-US/docs/Web/HTML/Element/form">form</a> owner.</td>
+  </tr>
+  <tr>
+   <td><code>formtarget</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a></td>
+   <td>If the button/input is a submit button (<code>type="submit"</code>), this attribute specifies the browsing context (for example, tab, window, or inline frame) in which to display the response that is received after submitting the form. If this attribute is specified, it overrides the <code>target</code> attribute of the button's <a href="/en-US/docs/Web/HTML/Element/form">form</a> owner.</td>
   </tr>
   <tr>
    <td><code>headers</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/td" title="The Table cell HTML element (&lt;td>) defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/th" title="The HTML element table header cell &lt;th> defines a cell as a header for a group of cells of a table. The group of cells that the header refers to is defined by the scope and headers attribute."><code>&lt;th&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/td" title="The HTML &lt;td> element defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/th" title="The HTML &lt;th> element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes."><code>&lt;th&gt;</code></a></td>
    <td>IDs of the <code>&lt;th&gt;</code> elements which applies to this element.</td>
   </tr>
   <tr>
    <td><code>height</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/canvas" title="The HTML &lt;canvas> Element can be used to draw graphics via scripting (usually JavaScript). For example, it can be used to draw graphs, make photo compositions or even perform animations. You may (and should) provide alternate content inside the &lt;canvas> block. That content will be rendered both on older browsers that don't support canvas and in browsers with JavaScript disabled."><code>&lt;canvas&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/embed" title="The HTML &lt;embed> Element represents an integration point for an external application or interactive content (in other words, a plug-in)."><code>&lt;embed&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame Element (&lt;iframe>) represents a nested browsing context, effectively embedding another HTML page into the current page. In HTML 4.01, a document may contain a head and a body or a head and a frame-set, but not both a body and a frame-set. However, an &lt;iframe> can be used within a normal document body. Each browsing context has its own session history and active document. The browsing context that contains the embedded content is called the parent browsing context. The top-level browsing context (which has no parent) is typically the browser window."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element represents an image in the document."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML Embedded Object Element (&lt;object>) represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="Editorial review completed."><code>&lt;video&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/canvas" title="Use the HTML &lt;canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations."><code>&lt;canvas&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/embed" title="The HTML &lt;embed> element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in."><code>&lt;embed&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML &lt;object> element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></td>
    <td>
-    <p>Specifies the height of elements listed here. For all other elements, use the CSS <a href="/en-US/docs/Web/CSS/height" title="The height CSS property specifies the height of the content area of an element. The content area is inside the padding, border, and margin of the element."><code>height</code></a> property.</p>
+    <p>Specifies the height of elements listed here. For all other elements, use the CSS <a href="/en-US/docs/Web/CSS/height" title="The height CSS property specifies the height of an element. By default, the property defines the height of the content area. If box-sizing is set to border-box, however, it instead determines the height of the border area."><code>height</code></a> property.</p>
 
     <div class="note">
-    <p><strong>Note:</strong> In some instances, such as <a href="/en-US/docs/Web/HTML/Element/div" title="The HTML &lt;div> element (or HTML Document Division Element) is the generic container for flow content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element (such as &lt;article> or &lt;nav>) is appropriate."><code>&lt;div&gt;</code></a>, this is a legacy attribute, in which case the CSS <a href="/en-US/docs/Web/CSS/height" title="The height CSS property specifies the height of the content area of an element. The content area is inside the padding, border, and margin of the element."><code>height</code></a> property should be used instead.</p>
+    <p><strong>Note:</strong> In some instances, such as <a href="/en-US/docs/Web/HTML/Element/div" title="The HTML Content Division element (&lt;div>) is the generic container for flow content. It has no effect on the content or layout until styled using CSS."><code>&lt;div&gt;</code></a>, this is a legacy attribute, in which case the CSS <a href="/en-US/docs/Web/CSS/height" title="The height CSS property specifies the height of an element. By default, the property defines the height of the content area. If box-sizing is set to border-box, however, it instead determines the height of the border area."><code>height</code></a> property should be used instead.</p>
     </div>
    </td>
   </tr>
   <tr>
    <td><code>hidden</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Prevents rendering of given element, while keeping child elements, e.g. script elements, active.</td>
   </tr>
   <tr>
    <td><code>high</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> Element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a></td>
    <td>Indicates the lower bound of the upper range.</td>
   </tr>
   <tr>
    <td><code>href</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML Anchor Element (&lt;a>) defines a hyperlink to a location on the same page or any other page on the Web. It can also be used (in an obsolete way) to create an anchor point—a destination for hyperlinks within the content of a page, so that links aren't limited to connecting simply to the top of a page."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/base" title="The HTML &lt;base> element specifies the base URL to use for all relative URLs contained within a document. There can be only one &lt;base> element in a document."><code>&lt;base&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/link" title="The HTML &lt;link> element specifies relationships between the current document and an external resource. Possible uses for this element include defining a relational framework for navigation. This Element is most used to link to style sheets."><code>&lt;link&gt;</code></a></td>
-   <td> The URL of a linked resource.</td>
+   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML &lt;a> element (or anchor element), along with it's href attribute, creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/base" title="The HTML &lt;base> element specifies the base URL to use for all relative URLs contained within a document. There can be only one &lt;base> element in a document."><code>&lt;base&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/link" title='The HTML External Resource Link element (&lt;link>) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and mobile home screen/app icons) among other things.'><code>&lt;link&gt;</code></a></td>
+   <td>The URL of a linked resource.</td>
   </tr>
   <tr>
    <td><code>hreflang</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML Anchor Element (&lt;a>) defines a hyperlink to a location on the same page or any other page on the Web. It can also be used (in an obsolete way) to create an anchor point—a destination for hyperlinks within the content of a page, so that links aren't limited to connecting simply to the top of a page."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/link" title="The HTML &lt;link> element specifies relationships between the current document and an external resource. Possible uses for this element include defining a relational framework for navigation. This Element is most used to link to style sheets."><code>&lt;link&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML &lt;a> element (or anchor element), along with it's href attribute, creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/link" title='The HTML External Resource Link element (&lt;link>) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and mobile home screen/app icons) among other things.'><code>&lt;link&gt;</code></a></td>
    <td>Specifies the language of the linked resource.</td>
   </tr>
   <tr>
    <td><code>http-equiv</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/meta" title="The HTML &lt;meta> element represents any metadata information that cannot be represented by one of the other HTML meta-related elements (&lt;base>, &lt;link>, &lt;script>, &lt;style> or &lt;title>)."><code>&lt;meta&gt;</code></a></td>
-   <td> </td>
+   <td><a href="/en-US/docs/Web/HTML/Element/meta" title="The HTML &lt;meta> element represents metadata that cannot be represented by other HTML meta-related elements, like &lt;base>, &lt;link>, &lt;script>, &lt;style> or &lt;title>."><code>&lt;meta&gt;</code></a></td>
+   <td>Defines a pragma directive.</td>
   </tr>
   <tr>
    <td><code>icon</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/command" title="The command element represents a command which the user can invoke."><code>&lt;command&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/command" title="The HTML Command element (&lt;command>) represents a command which the user can invoke. Commands are often used as part of a context menu or toolbar."><code>&lt;command&gt;</code></a></td>
    <td>Specifies a picture which represents the command.</td>
   </tr>
   <tr>
    <td><code>id</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Often used with CSS to style a specific element. The value of this attribute must be unique.</td>
   </tr>
   <tr>
+   <td><code>importance</code> <span title="This is an experimental API that should not be used in production code."><i class="icon-beaker"> </i></span></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/link" title='The HTML External Resource Link element (&lt;link>) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and mobile home screen/app icons) among other things.'><code>&lt;link&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/script" title="The HTML &lt;script> element is used to embed or reference executable code; this is typically used to embed or refer to JavaScript code."><code>&lt;script&gt;</code></a></td>
+   <td>Indicates the relative fetch priority for the resource.</td>
+  </tr>
+  <tr>
+   <td><code>integrity</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/link" title='The HTML External Resource Link element (&lt;link>) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and mobile home screen/app icons) among other things.'><code>&lt;link&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/script" title="The HTML &lt;script> element is used to embed or reference executable code; this is typically used to embed or refer to JavaScript code."><code>&lt;script&gt;</code></a></td>
+   <td>
+    <p>Specifies a <a href="https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity">Subresource Integrity</a> value that allows browsers to verify what they fetch.</p>
+   </td>
+  </tr>
+  <tr>
+   <td><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-intrinsicsize"><code>intrinsicsize</code></a> <span title="This is an experimental API that should not be used in production code."><i class="icon-beaker"> </i></span></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a></td>
+   <td>This attribute tells the browser to ignore the actual intrinsic size of the image and pretend it’s the size specified in the attribute.</td>
+  </tr>
+  <tr>
+   <td><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode"><code>inputmode</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a>, <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable"><code>contenteditable</code></a></td>
+   <td>Provides a hint as to the type of data that might be entered by the user while editing the element or its contents. The attribute can be used with form controls (such as the value of <code>textarea</code> elements), or in elements in an editing host (e.g., using <code>contenteditable</code> attribute).</td>
+  </tr>
+  <tr>
    <td><code>ismap</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element represents an image in the document."><code>&lt;img&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a></td>
    <td>Indicates that the image is part of a server-side image map.</td>
   </tr>
   <tr>
    <td><code>itemprop</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td> </td>
   </tr>
   <tr>
@@ -973,293 +931,317 @@
   </tr>
   <tr>
    <td><code>kind</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/track" title="The HTML &lt;track> element is used as a child of the media elements—&lt;audio> and &lt;video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks."><code>&lt;track&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/track" title="The HTML &lt;track> element is used as a child of the media elements &lt;audio> and &lt;video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks or Timed Text Markup Language (TTML)."><code>&lt;track&gt;</code></a></td>
    <td>Specifies the kind of text track.</td>
   </tr>
   <tr>
    <td><code>label</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/track" title="The HTML &lt;track> element is used as a child of the media elements—&lt;audio> and &lt;video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks."><code>&lt;track&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/track" title="The HTML &lt;track> element is used as a child of the media elements &lt;audio> and &lt;video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks or Timed Text Markup Language (TTML)."><code>&lt;track&gt;</code></a></td>
    <td>Specifies a user-readable title of the text track.</td>
   </tr>
   <tr>
-   <td><code>lang</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><code><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang">lang</a></code></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Defines the language used in the element.</td>
   </tr>
   <tr>
    <td><code>language</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/script" title="The HTML Script Element (&lt;script>) is used to embed or reference an executable script within an HTML or XHTML document."><code>&lt;script&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/script" title="The HTML &lt;script> element is used to embed or reference executable code; this is typically used to embed or refer to JavaScript code."><code>&lt;script&gt;</code></a></td>
    <td>Defines the script language used in the element.</td>
   </tr>
   <tr>
+   <td><code>loading</code> <span title="This is an experimental API that should not be used in production code."><i class="icon-beaker"> </i></span></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a></td>
+   <td>Indicates if the element should be loaded lazily.
+    <div class="note"><strong>WIP:</strong> <a class="external" href="https://github.com/whatwg/html/pull/3752" rel="noopener">WHATWG PR #3752</a></div>
+   </td>
+  </tr>
+  <tr>
    <td><code>list</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a></td>
    <td>Identifies a list of pre-defined options to suggest to the user.</td>
   </tr>
   <tr>
    <td><code>loop</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element; the browser will choose the most suitable one."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/bgsound" title="The HTML Background Sound Element () is an Internet Explorer element associating a background sound with a page."><code>&lt;bgsound&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/marquee" title="The HTML &lt;marquee> element is used to insert a scrolling area of text."><code>&lt;marquee&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="Editorial review completed."><code>&lt;video&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/bgsound" title="The Internet Explorer only HTML Background Sound element (&lt;bgsound>) sets up a sound file to play in the background while the page is used; use &lt;audio> instead."><code>&lt;bgsound&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/marquee" title="The HTML &lt;marquee> element is used to insert a scrolling area of text. You can control what happens when the text reaches the edges of its content area using its attributes."><code>&lt;marquee&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></td>
    <td>Indicates whether the media should start playing from the start when it's finished.</td>
   </tr>
   <tr>
    <td><code>low</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> Element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a></td>
    <td>Indicates the upper bound of the lower range.</td>
   </tr>
   <tr>
    <td><code>manifest</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/html" title="The HTML &lt;html> element (or HTML root element) represents the root of an HTML document. All other elements must be descendants of this element."><code>&lt;html&gt;</code></a></td>
-   <td>Specifies the URL of the document's cache manifest.</td>
+   <td><a href="/en-US/docs/Web/HTML/Element/html" title="The HTML &lt;html> element represents the root (top-level element) of an HTML document, so it is also referred to as the root element. All other elements must be descendants of this element."><code>&lt;html&gt;</code></a></td>
+   <td>Specifies the URL of the document's cache manifest.
+    <div class="note"><strong>Note:</strong> This attribute is obsolete, use <a href="https://developer.mozilla.org/en-US/docs/Web/Manifest"><code>&lt;link rel="manifest"&gt;</code></a> instead.</div>
+   </td>
   </tr>
   <tr>
    <td><code>max</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> Element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/progress" title="The HTML &lt;progress> Element is used to view the completion progress of a task. While the specifics of how it's displayed is left up to the browser developer, it's typically displayed as a progress bar. Javascript can be used to manipulate the value of progress bar."><code>&lt;progress&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/progress" title="The HTML &lt;progress> element displays an indicator showing the completion progress of a task, typically displayed as a progress bar."><code>&lt;progress&gt;</code></a></td>
    <td>Indicates the maximum value allowed.</td>
   </tr>
   <tr>
    <td><code>maxlength</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td>Defines the maximum number of characters allowed in the element.</td>
   </tr>
   <tr>
+   <td><code>minlength</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
+   <td>Defines the minimum number of characters allowed in the element.</td>
+  </tr>
+  <tr>
    <td><code>media</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML Anchor Element (&lt;a>) defines a hyperlink to a location on the same page or any other page on the Web. It can also be used (in an obsolete way) to create an anchor point—a destination for hyperlinks within the content of a page, so that links aren't limited to connecting simply to the top of a page."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/link" title="The HTML &lt;link> element specifies relationships between the current document and an external resource. Possible uses for this element include defining a relational framework for navigation. This Element is most used to link to style sheets."><code>&lt;link&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/source" title="The HTML &lt;source> element specifies multiple media resources for either the &lt;picture>, the &lt;audio> or the &lt;video> element. It is an empty element. It is commonly used to serve the same media content in multiple formats supported by different browsers."><code>&lt;source&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/style" title="The HTML &lt;style> element contains style information for a document, or part of a document. By default, the style instructions written inside that element are expected to be CSS."><code>&lt;style&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML &lt;a> element (or anchor element), along with it's href attribute, creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/link" title='The HTML External Resource Link element (&lt;link>) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and mobile home screen/app icons) among other things.'><code>&lt;link&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/source" title="The HTML &lt;source> element specifies multiple media resources for the &lt;picture>, the &lt;audio> element, or the &lt;video> element."><code>&lt;source&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/style" title="The HTML &lt;style> element contains style information for a document, or part of a document."><code>&lt;style&gt;</code></a></td>
    <td>Specifies a hint of the media for which the linked resource was designed.</td>
   </tr>
   <tr>
    <td><code>method</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls to submit information to a web server."><code>&lt;form&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls for submitting information to a web server."><code>&lt;form&gt;</code></a></td>
    <td>Defines which <a href="/en-US/docs/Web/HTTP">HTTP</a> method to use when submitting the form. Can be <code>GET</code> (default) or <code>POST</code>.</td>
   </tr>
   <tr>
    <td><code>min</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> Element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a></td>
    <td>Indicates the minimum value allowed.</td>
   </tr>
   <tr>
    <td><code>multiple</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML select (&lt;select>) element represents a control that presents a menu of options. The options within the menu are represented by &lt;option> elements, which can be grouped by &lt;optgroup> elements. Options can be pre-selected for the user."><code>&lt;select&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML &lt;select> element represents a control that provides a menu of options"><code>&lt;select&gt;</code></a></td>
    <td>Indicates whether multiple values can be entered in an input of the type <code>email</code> or <code>file</code>.</td>
   </tr>
   <tr>
    <td><code>muted</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/video" title="Editorial review completed."><code>&lt;video&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></td>
    <td>Indicates whether the audio will be initially silenced on page load.</td>
   </tr>
   <tr>
    <td><code>name</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> Element represents a clickable button."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls to submit information to a web server."><code>&lt;form&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/fieldset" title="The HTML &lt;fieldset> element is used to group several controls as well as labels (&lt;label>) within a web form."><code>&lt;fieldset&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame Element (&lt;iframe>) represents a nested browsing context, effectively embedding another HTML page into the current page. In HTML 4.01, a document may contain a head and a body or a head and a frame-set, but not both a body and a frame-set. However, an &lt;iframe> can be used within a normal document body. Each browsing context has its own session history and active document. The browsing context that contains the embedded content is called the parent browsing context. The top-level browsing context (which has no parent) is typically the browser window."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/keygen" title="The HTML &lt;keygen> element exists to facilitate generation of key material, and submission of the public key as part of an HTML form. This mechanism is designed for use with Web-based certificate management systems. It is expected that the &lt;keygen> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate."><code>&lt;keygen&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML Embedded Object Element (&lt;object>) represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/output" title="The HTML &lt;output> element represents the result of a calculation or user action."><code>&lt;output&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML select (&lt;select>) element represents a control that presents a menu of options. The options within the menu are represented by &lt;option> elements, which can be grouped by &lt;optgroup> elements. Options can be pre-selected for the user."><code>&lt;select&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/map" title="The HTML &lt;map> element is used with &lt;area> elements to define an image map (a clickable link area)."><code>&lt;map&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/meta" title="The HTML &lt;meta> element represents any metadata information that cannot be represented by one of the other HTML meta-related elements (&lt;base>, &lt;link>, &lt;script>, &lt;style> or &lt;title>)."><code>&lt;meta&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/param" title="The HTML &lt;param> Element (or HTML Parameter Element) defines parameters for &lt;object>."><code>&lt;param&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls for submitting information to a web server."><code>&lt;form&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/fieldset" title="The HTML &lt;fieldset> element is used to group several controls as well as labels (&lt;label>) within a web form."><code>&lt;fieldset&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/keygen" title="The HTML &lt;keygen> element exists to facilitate generation of key material, and submission of the public key as part of an HTML form. This mechanism is designed for use with Web-based certificate management systems. It is expected that the &lt;keygen> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate."><code>&lt;keygen&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML &lt;object> element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/output" title="The HTML Output element (&lt;output>) is a container element into which a site or app can inject the results of a calculation or the outcome of a user action."><code>&lt;output&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML &lt;select> element represents a control that provides a menu of options"><code>&lt;select&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/map" title="The HTML &lt;map> element is used with &lt;area> elements to define an image map (a clickable link area)."><code>&lt;map&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/meta" title="The HTML &lt;meta> element represents metadata that cannot be represented by other HTML meta-related elements, like &lt;base>, &lt;link>, &lt;script>, &lt;style> or &lt;title>."><code>&lt;meta&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/param" title="The HTML &lt;param> element defines parameters for an &lt;object> element."><code>&lt;param&gt;</code></a></td>
    <td>Name of the element. For example used by the server to identify the fields in form submits.</td>
   </tr>
   <tr>
    <td><code>novalidate</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls to submit information to a web server."><code>&lt;form&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls for submitting information to a web server."><code>&lt;form&gt;</code></a></td>
    <td>This attribute indicates that the form shouldn't be validated when submitted.</td>
   </tr>
   <tr>
    <td><code>open</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/details" title="The HTML Details Element (&lt;details>) is used as a disclosure widget from which the user can retrieve additional information."><code>&lt;details&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/details" title='The HTML Details Element (&lt;details>) creates a disclosure widget in which information is visible only when the widget is toggled into an "open" state.'><code>&lt;details&gt;</code></a></td>
    <td>Indicates whether the details will be shown on page load.</td>
   </tr>
   <tr>
    <td><code>optimum</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> Element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a></td>
    <td>Indicates the optimal numeric value.</td>
   </tr>
   <tr>
    <td><code>pattern</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a></td>
    <td>Defines a regular expression which the element's value will be validated against.</td>
   </tr>
   <tr>
-   <td><code>ping</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML Anchor Element (&lt;a>) defines a hyperlink to a location on the same page or any other page on the Web. It can also be used (in an obsolete way) to create an anchor point—a destination for hyperlinks within the content of a page, so that links aren't limited to connecting simply to the top of a page."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a></td>
-   <td> </td>
+   <td><code><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping">ping</a></code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML &lt;a> element (or anchor element), along with it's href attribute, creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a></td>
+   <td>The <code>ping</code> attribute specifies a space-separated list of URLs to be notified if a user follows the hyperlink.</td>
   </tr>
   <tr>
    <td><code>placeholder</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td>Provides a hint to the user of what can be entered in the field.</td>
   </tr>
   <tr>
    <td><code>poster</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/video" title="Editorial review completed."><code>&lt;video&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></td>
    <td>A URL indicating a poster frame to show until the user plays or seeks.</td>
   </tr>
   <tr>
    <td><code>preload</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element; the browser will choose the most suitable one."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="Editorial review completed."><code>&lt;video&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></td>
    <td>Indicates whether the whole resource, parts of it or nothing should be preloaded.</td>
   </tr>
   <tr>
    <td><code>radiogroup</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/command" title="The command element represents a command which the user can invoke."><code>&lt;command&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/command" title="The HTML Command element (&lt;command>) represents a command which the user can invoke. Commands are often used as part of a context menu or toolbar."><code>&lt;command&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>readonly</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td>Indicates whether the element can be edited.</td>
   </tr>
   <tr>
+   <td><code>referrerpolicy</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML &lt;a> element (or anchor element), along with it's href attribute, creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/link" title='The HTML External Resource Link element (&lt;link>) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and mobile home screen/app icons) among other things.'><code>&lt;link&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/script" title="The HTML &lt;script> element is used to embed or reference executable code; this is typically used to embed or refer to JavaScript code."><code>&lt;script&gt;</code></a></td>
+   <td>Specifies which referrer is sent when fetching the resource.</td>
+  </tr>
+  <tr>
    <td><code>rel</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML Anchor Element (&lt;a>) defines a hyperlink to a location on the same page or any other page on the Web. It can also be used (in an obsolete way) to create an anchor point—a destination for hyperlinks within the content of a page, so that links aren't limited to connecting simply to the top of a page."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/link" title="The HTML &lt;link> element specifies relationships between the current document and an external resource. Possible uses for this element include defining a relational framework for navigation. This Element is most used to link to style sheets."><code>&lt;link&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML &lt;a> element (or anchor element), along with it's href attribute, creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/link" title='The HTML External Resource Link element (&lt;link>) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and mobile home screen/app icons) among other things.'><code>&lt;link&gt;</code></a></td>
    <td>Specifies the relationship of the target object to the link object.</td>
   </tr>
   <tr>
    <td><code>required</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML select (&lt;select>) element represents a control that presents a menu of options. The options within the menu are represented by &lt;option> elements, which can be grouped by &lt;optgroup> elements. Options can be pre-selected for the user."><code>&lt;select&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML &lt;select> element represents a control that provides a menu of options"><code>&lt;select&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td>Indicates whether this element is required to fill out or not.</td>
   </tr>
   <tr>
    <td><code>reversed</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/ol" title="The HTML &lt;ol> Element (or HTML Ordered List Element) represents an ordered list of items. Typically, ordered-list items are displayed with a preceding numbering, which can be of any form, like numerals, letters or Romans numerals or even simple bullets. This numbered style is not defined in the HTML description of the page, but in its associated CSS, using the list-style-type property."><code>&lt;ol&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/ol" title="The HTML &lt;ol> element represents an ordered list of items, typically rendered as a numbered list."><code>&lt;ol&gt;</code></a></td>
    <td>Indicates whether the list should be displayed in a descending order instead of a ascending.</td>
   </tr>
   <tr>
    <td><code>rows</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td>Defines the number of rows in a text area.</td>
   </tr>
   <tr>
    <td><code>rowspan</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/td" title="The Table cell HTML element (&lt;td>) defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/th" title="The HTML element table header cell &lt;th> defines a cell as a header for a group of cells of a table. The group of cells that the header refers to is defined by the scope and headers attribute."><code>&lt;th&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/td" title="The HTML &lt;td> element defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/th" title="The HTML &lt;th> element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes."><code>&lt;th&gt;</code></a></td>
    <td>Defines the number of rows a table cell should span over.</td>
   </tr>
   <tr>
-   <td><code>sandbox</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame Element (&lt;iframe>) represents a nested browsing context, effectively embedding another HTML page into the current page. In HTML 4.01, a document may contain a head and a body or a head and a frame-set, but not both a body and a frame-set. However, an &lt;iframe> can be used within a normal document body. Each browsing context has its own session history and active document. The browsing context that contains the embedded content is called the parent browsing context. The top-level browsing context (which has no parent) is typically the browser window."><code>&lt;iframe&gt;</code></a></td>
-   <td> </td>
+   <td><code><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox">sandbox</a></code></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a></td>
+   <td>Stops a document loaded in an iframe from using certain features (such as submitting forms or opening new windows).</td>
   </tr>
   <tr>
    <td><code>scope</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/th" title="The HTML element table header cell &lt;th> defines a cell as a header for a group of cells of a table. The group of cells that the header refers to is defined by the scope and headers attribute."><code>&lt;th&gt;</code></a></td>
-   <td> </td>
+   <td><a href="/en-US/docs/Web/HTML/Element/th" title="The HTML &lt;th> element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes."><code>&lt;th&gt;</code></a></td>
+   <td>Defines the cells that the header test (defined in the <code>th</code> element) relates to.</td>
   </tr>
   <tr>
    <td><code>scoped</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/style" title="The HTML &lt;style> element contains style information for a document, or part of a document. By default, the style instructions written inside that element are expected to be CSS."><code>&lt;style&gt;</code></a></td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td><code>seamless</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame Element (&lt;iframe>) represents a nested browsing context, effectively embedding another HTML page into the current page. In HTML 4.01, a document may contain a head and a body or a head and a frame-set, but not both a body and a frame-set. However, an &lt;iframe> can be used within a normal document body. Each browsing context has its own session history and active document. The browsing context that contains the embedded content is called the parent browsing context. The top-level browsing context (which has no parent) is typically the browser window."><code>&lt;iframe&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/style" title="The HTML &lt;style> element contains style information for a document, or part of a document."><code>&lt;style&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>selected</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/option" title="In a Web form, the HTML &lt;option> element is used to create a control representing an item within a &lt;select>, an &lt;optgroup> or a &lt;datalist> HTML5 element."><code>&lt;option&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/option" title="The HTML &lt;option> element is used to define an item contained in a &lt;select>, an &lt;optgroup>, or a &lt;datalist> element. As such, &lt;option> can represent menu items in popups and other lists of items in an HTML document."><code>&lt;option&gt;</code></a></td>
    <td>Defines a value which will be selected on page load.</td>
   </tr>
   <tr>
    <td><code>shape</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML Anchor Element (&lt;a>) defines a hyperlink to a location on the same page or any other page on the Web. It can also be used (in an obsolete way) to create an anchor point—a destination for hyperlinks within the content of a page, so that links aren't limited to connecting simply to the top of a page."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML &lt;a> element (or anchor element), along with it's href attribute, creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>size</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML select (&lt;select>) element represents a control that presents a menu of options. The options within the menu are represented by &lt;option> elements, which can be grouped by &lt;optgroup> elements. Options can be pre-selected for the user."><code>&lt;select&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/select" title="The HTML &lt;select> element represents a control that provides a menu of options"><code>&lt;select&gt;</code></a></td>
    <td>Defines the width of the element (in pixels). If the element's <code>type</code> attribute is <code>text</code> or <code>password</code> then it's the number of characters.</td>
   </tr>
   <tr>
    <td><code>sizes</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/link" title="The HTML &lt;link> element specifies relationships between the current document and an external resource. Possible uses for this element include defining a relational framework for navigation. This Element is most used to link to style sheets."><code>&lt;link&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element represents an image in the document."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/source" title="The HTML &lt;source> element specifies multiple media resources for either the &lt;picture>, the &lt;audio> or the &lt;video> element. It is an empty element. It is commonly used to serve the same media content in multiple formats supported by different browsers."><code>&lt;source&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/link" title='The HTML External Resource Link element (&lt;link>) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and mobile home screen/app icons) among other things.'><code>&lt;link&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/source" title="The HTML &lt;source> element specifies multiple media resources for the &lt;picture>, the &lt;audio> element, or the &lt;video> element."><code>&lt;source&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
+   <td><code>slot</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
+   <td>Assigns a slot in a shadow DOM shadow tree to an element.</td>
+  </tr>
+  <tr>
    <td><code>span</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/col" title="The HTML Table Column Element (&lt;col>) defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a &lt;colgroup> element."><code>&lt;col&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/colgroup" title="The HTML Table Column Group Element (&lt;colgroup>) defines a group of columns within a table."><code>&lt;colgroup&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/col" title="The HTML &lt;col> element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a &lt;colgroup> element."><code>&lt;col&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/colgroup" title="The HTML &lt;colgroup> element defines a group of columns within a table."><code>&lt;colgroup&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>spellcheck</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Indicates whether spell checking is allowed for the element.</td>
   </tr>
   <tr>
    <td><code>src</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element; the browser will choose the most suitable one."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/embed" title="The HTML &lt;embed> Element represents an integration point for an external application or interactive content (in other words, a plug-in)."><code>&lt;embed&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame Element (&lt;iframe>) represents a nested browsing context, effectively embedding another HTML page into the current page. In HTML 4.01, a document may contain a head and a body or a head and a frame-set, but not both a body and a frame-set. However, an &lt;iframe> can be used within a normal document body. Each browsing context has its own session history and active document. The browsing context that contains the embedded content is called the parent browsing context. The top-level browsing context (which has no parent) is typically the browser window."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element represents an image in the document."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/script" title="The HTML Script Element (&lt;script>) is used to embed or reference an executable script within an HTML or XHTML document."><code>&lt;script&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/source" title="The HTML &lt;source> element specifies multiple media resources for either the &lt;picture>, the &lt;audio> or the &lt;video> element. It is an empty element. It is commonly used to serve the same media content in multiple formats supported by different browsers."><code>&lt;source&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/track" title="The HTML &lt;track> element is used as a child of the media elements—&lt;audio> and &lt;video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks."><code>&lt;track&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="Editorial review completed."><code>&lt;video&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream."><code>&lt;audio&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/embed" title="The HTML &lt;embed> element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in."><code>&lt;embed&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/script" title="The HTML &lt;script> element is used to embed or reference executable code; this is typically used to embed or refer to JavaScript code."><code>&lt;script&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/source" title="The HTML &lt;source> element specifies multiple media resources for the &lt;picture>, the &lt;audio> element, or the &lt;video> element."><code>&lt;source&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/track" title="The HTML &lt;track> element is used as a child of the media elements &lt;audio> and &lt;video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks or Timed Text Markup Language (TTML)."><code>&lt;track&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></td>
    <td>The URL of the embeddable content.</td>
   </tr>
   <tr>
    <td><code>srcdoc</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame Element (&lt;iframe>) represents a nested browsing context, effectively embedding another HTML page into the current page. In HTML 4.01, a document may contain a head and a body or a head and a frame-set, but not both a body and a frame-set. However, an &lt;iframe> can be used within a normal document body. Each browsing context has its own session history and active document. The browsing context that contains the embedded content is called the parent browsing context. The top-level browsing context (which has no parent) is typically the browser window."><code>&lt;iframe&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>srclang</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/track" title="The HTML &lt;track> element is used as a child of the media elements—&lt;audio> and &lt;video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks."><code>&lt;track&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/track" title="The HTML &lt;track> element is used as a child of the media elements &lt;audio> and &lt;video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks or Timed Text Markup Language (TTML)."><code>&lt;track&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>srcset</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element represents an image in the document."><code>&lt;img&gt;</code></a></td>
-   <td> </td>
+   <td><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/source" title="The HTML &lt;source> element specifies multiple media resources for the &lt;picture>, the &lt;audio> element, or the &lt;video> element."><code>&lt;source&gt;</code></a></td>
+   <td>One or more responsive image candidates.</td>
   </tr>
   <tr>
    <td><code>start</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/ol" title="The HTML &lt;ol> Element (or HTML Ordered List Element) represents an ordered list of items. Typically, ordered-list items are displayed with a preceding numbering, which can be of any form, like numerals, letters or Romans numerals or even simple bullets. This numbered style is not defined in the HTML description of the page, but in its associated CSS, using the list-style-type property."><code>&lt;ol&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/ol" title="The HTML &lt;ol> element represents an ordered list of items, typically rendered as a numbered list."><code>&lt;ol&gt;</code></a></td>
    <td>Defines the first number if other than 1.</td>
   </tr>
   <tr>
    <td><code>step</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>style</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Defines CSS styles which will override styles previously set.</td>
   </tr>
   <tr>
    <td><code>summary</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/table" title="The HTML Table Element (&lt;table>) represents tabular data: information expressed via two dimensions or more."><code>&lt;table&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/table" title="The HTML &lt;table> element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data."><code>&lt;table&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
-   <td><code>tabindex</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><code><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex">tabindex</a></code></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Overrides the browser's default tab order and follows the one specified instead.</td>
   </tr>
   <tr>
    <td><code>target</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML Anchor Element (&lt;a>) defines a hyperlink to a location on the same page or any other page on the Web. It can also be used (in an obsolete way) to create an anchor point—a destination for hyperlinks within the content of a page, so that links aren't limited to connecting simply to the top of a page."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/base" title="The HTML &lt;base> element specifies the base URL to use for all relative URLs contained within a document. There can be only one &lt;base> element in a document."><code>&lt;base&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls to submit information to a web server."><code>&lt;form&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML &lt;a> element (or anchor element), along with it's href attribute, creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL."><code>&lt;a&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/base" title="The HTML &lt;base> element specifies the base URL to use for all relative URLs contained within a document. There can be only one &lt;base> element in a document."><code>&lt;base&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls for submitting information to a web server."><code>&lt;form&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>title</code></td>
-   <td><a href="/en/HTML/Global_attributes" title="en/HTML/Global attributes">Global attribute</a></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Text to be displayed in a tooltip when hovering over the element.</td>
   </tr>
   <tr>
+   <td><code>translate</code></td>
+   <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
+   <td>Specify whether an element’s attribute values and the values of its <code><a class="external" href="https://dom.spec.whatwg.org/#text" id="ref-for-text①⑦" rel="noopener">Text</a></code> node children are to be translated when the page is localized, or whether to leave them unchanged.</td>
+  </tr>
+  <tr>
    <td><code>type</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> Element represents a clickable button."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/command" title="The command element represents a command which the user can invoke."><code>&lt;command&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/embed" title="The HTML &lt;embed> Element represents an integration point for an external application or interactive content (in other words, a plug-in)."><code>&lt;embed&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML Embedded Object Element (&lt;object>) represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/script" title="The HTML Script Element (&lt;script>) is used to embed or reference an executable script within an HTML or XHTML document."><code>&lt;script&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/source" title="The HTML &lt;source> element specifies multiple media resources for either the &lt;picture>, the &lt;audio> or the &lt;video> element. It is an empty element. It is commonly used to serve the same media content in multiple formats supported by different browsers."><code>&lt;source&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/style" title="The HTML &lt;style> element contains style information for a document, or part of a document. By default, the style instructions written inside that element are expected to be CSS."><code>&lt;style&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/menu" title="The HTML &lt;menu> element represents a group of commands that a user can perform or activate. This includes both list menus, which might appear across the top of a screen, as well as context menus, such as those that might appear underneath a button after it has been clicked."><code>&lt;menu&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/command" title="The HTML Command element (&lt;command>) represents a command which the user can invoke. Commands are often used as part of a context menu or toolbar."><code>&lt;command&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/embed" title="The HTML &lt;embed> element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in."><code>&lt;embed&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML &lt;object> element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/script" title="The HTML &lt;script> element is used to embed or reference executable code; this is typically used to embed or refer to JavaScript code."><code>&lt;script&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/source" title="The HTML &lt;source> element specifies multiple media resources for the &lt;picture>, the &lt;audio> element, or the &lt;video> element."><code>&lt;source&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/style" title="The HTML &lt;style> element contains style information for a document, or part of a document."><code>&lt;style&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/menu" title="The HTML &lt;menu> element represents a group of commands that a user can perform or activate. This includes both list menus, which might appear across the top of a screen, as well as context menus, such as those that might appear underneath a button after it has been clicked."><code>&lt;menu&gt;</code></a></td>
    <td>Defines the type of the element.</td>
   </tr>
   <tr>
    <td><code>usemap</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element represents an image in the document."><code>&lt;img&gt;</code></a>,  <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML Embedded Object Element (&lt;object>) represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML &lt;object> element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>value</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> Element represents a clickable button."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/option" title="In a Web form, the HTML &lt;option> element is used to create a control representing an item within a &lt;select>, an &lt;optgroup> or a &lt;datalist> HTML5 element."><code>&lt;option&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/li" title="The HTML &lt;li> element (or HTML List Item Element) is used to represent an item in a list. It must be contained in a parent element: an ordered list (&lt;ol>), an unordered list (&lt;ul>), or a menu (&lt;menu>). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter."><code>&lt;li&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> Element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/progress" title="The HTML &lt;progress> Element is used to view the completion progress of a task. While the specifics of how it's displayed is left up to the browser developer, it's typically displayed as a progress bar. Javascript can be used to manipulate the value of progress bar."><code>&lt;progress&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/param" title="The HTML &lt;param> Element (or HTML Parameter Element) defines parameters for &lt;object>."><code>&lt;param&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/data" title="The HTML &lt;data> element links a given content with a machine-readable translation. If the content is time- or date-related, the &lt;time> element must be used."><code>&lt;data&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/li" title="The HTML &lt;li> element is used to represent an item in a list. It must be contained in a parent element: an ordered list (&lt;ol>), an unordered list (&lt;ul>), or a menu (&lt;menu>). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter."><code>&lt;li&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/option" title="The HTML &lt;option> element is used to define an item contained in a &lt;select>, an &lt;optgroup>, or a &lt;datalist> element. As such, &lt;option> can represent menu items in popups and other lists of items in an HTML document."><code>&lt;option&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/progress" title="The HTML &lt;progress> element displays an indicator showing the completion progress of a task, typically displayed as a progress bar."><code>&lt;progress&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/param" title="The HTML &lt;param> element defines parameters for an &lt;object> element."><code>&lt;param&gt;</code></a></td>
    <td>Defines a default value which will be displayed in the element on page load.</td>
   </tr>
   <tr>
    <td><code>width</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/canvas" title="The HTML &lt;canvas> Element can be used to draw graphics via scripting (usually JavaScript). For example, it can be used to draw graphs, make photo compositions or even perform animations. You may (and should) provide alternate content inside the &lt;canvas> block. That content will be rendered both on older browsers that don't support canvas and in browsers with JavaScript disabled."><code>&lt;canvas&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/embed" title="The HTML &lt;embed> Element represents an integration point for an external application or interactive content (in other words, a plug-in)."><code>&lt;embed&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame Element (&lt;iframe>) represents a nested browsing context, effectively embedding another HTML page into the current page. In HTML 4.01, a document may contain a head and a body or a head and a frame-set, but not both a body and a frame-set. However, an &lt;iframe> can be used within a normal document body. Each browsing context has its own session history and active document. The browsing context that contains the embedded content is called the parent browsing context. The top-level browsing context (which has no parent) is typically the browser window."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element represents an image in the document."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML Embedded Object Element (&lt;object>) represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="Editorial review completed."><code>&lt;video&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/canvas" title="Use the HTML &lt;canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations."><code>&lt;canvas&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/embed" title="The HTML &lt;embed> element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in."><code>&lt;embed&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/object" title="The HTML &lt;object> element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a>, <a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></td>
    <td>
     <p>For the elements listed here, this establishes the element's width.</p>
 
     <div class="note">
-    <p><strong>Note:</strong> For all other instances, such as <a href="/en-US/docs/Web/HTML/Element/div" title="The HTML &lt;div> element (or HTML Document Division Element) is the generic container for flow content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element (such as &lt;article> or &lt;nav>) is appropriate."><code>&lt;div&gt;</code></a>, this is a legacy attribute, in which case the CSS <a href="/en-US/docs/Web/CSS/width" title="The width CSS property specifies the width of the content area of an element. The content area is inside the padding, border, and margin of the element."><code>width</code></a> property should be used instead.</p>
+    <p><strong>Note:</strong> For all other instances, such as <a href="/en-US/docs/Web/HTML/Element/div" title="The HTML Content Division element (&lt;div>) is the generic container for flow content. It has no effect on the content or layout until styled using CSS."><code>&lt;div&gt;</code></a>, this is a legacy attribute, in which case the CSS <a href="/en-US/docs/Web/CSS/width" title="The width CSS property sets an element's width. By default, it sets the width of the content area, but if box-sizing is set to border-box, it sets the width of the border area."><code>width</code></a> property should be used instead.</p>
     </div>
    </td>
   </tr>
   <tr>
    <td><code>wrap</code></td>
-   <td><a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control."><code>&lt;textarea&gt;</code></a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></td>
    <td>Indicates whether the text should be wrapped.</td>
   </tr>
  </tbody>
@@ -1267,206 +1249,487 @@
 
 <h2 id="Content_versus_IDL_attributes">Content versus IDL attributes</h2>
 
-<p>In HTML, most attributes have two faces: the <strong>content attribute</strong> and the <strong>IDL attribute</strong>.</p>
+<p>In HTML, most attributes have two faces: the <strong>content attribute</strong> and the <strong>IDL (Interface Definition Language) attribute</strong>.</p>
 
-<p>The content attribute is the attribute as you set it from the content (the HTML code) and you can set it or get it via <a href="/en-US/docs/Web/API/Element/setAttribute" title="Adds a new attribute or changes the value of an existing attribute on the specified element."><code>element.setAttribute()</code></a> or <a href="/en-US/docs/Web/API/Element/getAttribute" title="getAttribute() returns the value of a specified attribute on the element."><code>element.getAttribute()</code></a>. The content attribute is always a string even when the expected value should be an integer. For example, to set an <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a> element's <code>maxlength</code> to 42 using the content attribute, you have to call <code>setAttribute("maxlength", "42")</code> on that element.</p>
+<p>The content attribute is the attribute as you set it from the content (the HTML code) and you can set it or get it via <a href="/en-US/docs/Web/API/Element/setAttribute" title="Sets the value of an attribute on the specified element. If the attribute already exists, the value is updated; otherwise a new attribute is added with the specified name and value."><code>element.setAttribute()</code></a> or <a href="/en-US/docs/Web/API/Element/getAttribute" title="The getAttribute() method of the Element interface returns the value of a specified attribute on the element."><code>element.getAttribute()</code></a>. The content attribute is always a string even when the expected value should be an integer. For example, to set an <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a> element's <code>maxlength</code> to 42 using the content attribute, you have to call <code>setAttribute("maxlength", "42")</code> on that element.</p>
 
 <p>The IDL attribute is also known as a JavaScript property. These are the attributes you can read or set using JavaScript properties like <code class="moz-txt-verticalline">element.foo</code>. The IDL attribute is always going to use (but might transform) the underlying content attribute to return a value when you get it and is going to save something in the content attribute when you set it. In other words, the IDL attributes, in essence, reflect the content attributes.</p>
 
-<p>Most of the time, IDL attributes will return their values as they are really used. For example, the default <code>type</code> for <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML element &lt;input> is used to create interactive controls for web-based forms in order to accept data from the user. How an &lt;input> works varies considerably depending on the value of its type attribute."><code>&lt;input&gt;</code></a> elements is "text", so if you set <code>input.type="foobar"</code>, the <code>&lt;input&gt;</code> element will be of type text (in the appearance and the behavior) but the "type" content attribute's value will be "foobar". However, the <code>type</code> IDL attribute will return the string "text".</p>
+<p>Most of the time, IDL attributes will return their values as they are really used. For example, the default <code>type</code> for <a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a> elements is "text", so if you set <code>input.type="foobar"</code>, the <code>&lt;input&gt;</code> element will be of type text (in the appearance and the behavior) but the "type" content attribute's value will be "foobar". However, the <code>type</code> IDL attribute will return the string "text".</p>
 
 <p>IDL attributes are not always strings; for example, <code>input.maxlength</code> is a number (a signed long). When using IDL attributes, you read or set values of the desired type, so <code>input.maxlength</code> is always going to return a number and when you set <code>input.maxlength</code> ,it wants a number. If you pass another type, it is automatically converted to a number as specified by the standard JavaScript rules for type conversion.</p>
 
-<p>IDL attributes can <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/urls.html#reflecting-content-attributes-in-idl-attributes" class="external" title="http://www.whatwg.org/specs/web-apps/current-work/multipage/urls.html#reflecting-content-attributes-in-idl-attributes">reflect other types</a> such as unsigned long, URLs, booleans, etc. Unfortunately, there are no clear rules and the way IDL attributes behave in conjunction with their corresponding content attributes depends on the attribute. Most of the time, it will follow <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/urls.html#reflecting-content-attributes-in-idl-attributes" class="external" title="http://www.whatwg.org/specs/web-apps/current-work/multipage/urls.html#reflecting-content-attributes-in-idl-attributes">the rules laid out in the specification</a>, but sometimes it doesn't. HTML specifications try to make this as developer-friendly as possible, but for various reasons (mostly historical), some attributes  behave oddly (<code>select.size</code>, for example) and you should read the specifications to understand how exactly they behave.</p>
+<p>IDL attributes can <a class="external" href="https://www.whatwg.org/specs/web-apps/current-work/multipage/urls.html#reflecting-content-attributes-in-idl-attributes" rel="noopener">reflect other types</a> such as unsigned long, URLs, booleans, etc. Unfortunately, there are no clear rules and the way IDL attributes behave in conjunction with their corresponding content attributes depends on the attribute. Most of the time, it will follow <a class="external" href="https://www.whatwg.org/specs/web-apps/current-work/multipage/urls.html#reflecting-content-attributes-in-idl-attributes" rel="noopener">the rules laid out in the specification</a>, but sometimes it doesn't. HTML specifications try to make this as developer-friendly as possible, but for various reasons (mostly historical), some attributes behave oddly (<code>select.size</code>, for example) and you should read the specifications to understand how exactly they behave.</p>
+
+<h2 id="Boolean_Attributes">Boolean Attributes</h2>
+
+<p>Some content attributes (e.g. <code>required</code>, <code>readonly</code>, <code>disabled</code>) are called <a class="external" href="https://www.w3.org/TR/html52/infrastructure.html#sec-boolean-attributes" rel="noopener">boolean attributes</a>. If a boolean attribute is present, its value is <strong>true</strong>, and if it’s absent, its value is <strong>false</strong>.</p>
+
+<p>HTML5 defines restrictions on the allowed values of boolean attributes: If the attribute is present, its value must either be the empty string (equivalently, the attribute may have an unassigned value), or a value that is an ASCII case-insensitive match for the attribute’s canonical name, with no leading or trailing whitespace. The following examples are valid ways to mark up a boolean attribute:</p>
+
+<pre>&lt;div itemscope&gt; This is valid HTML but invalid XML. &lt;/div&gt;
+&lt;div itemscope=itemscope&gt; This is also valid HTML but invalid XML. &lt;/div&gt;
+&lt;div itemscope=""&gt; This is valid HTML and also valid XML. &lt;/div&gt;
+&lt;div itemscope="itemscope"&gt; This is also valid HTML and XML, but perhaps a bit verbose. &lt;/div&gt;</pre>
+
+<p>To be clear, the values <code>"true"</code> and <code>"false"</code> are not allowed on boolean attributes. To represent a false value, the attribute has to be omitted altogether. This restriction clears up some common misunderstandings: With <code>checked="false"</code> for example, the element’s <code>checked</code> attribute would be interpreted as <strong>true</strong> because the attribute is present.</p>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/HTML/Element" title="/en-US/docs/HTML/Element">HTML elements</a></li>
+ <li><a href="/en-US/docs/Web/HTML/Element">HTML elements</a></li>
 </ul>
 
 
               </article>
 
-
-
-                <!-- contributors -->
-                <div class="wiki-block contributors">
-                  <h2 class="offscreen">Document Tags and Contributors</h2>
+              <!-- contributors -->
+              <div class="wiki-block contributors">
+                <h2 class="offscreen">Document Tags and Contributors</h2>
 
 
   <div class="tag-attach-list contributors-sub">
-    <i aria-hidden="true" class="icon-tags icon-fw"></i>
+    <svg class="icon icon-tags" xmlns="http://www.w3.org/2000/svg" width="30" height="28" viewBox="0 0 30 28" aria-hidden="true">
+    <path d="M7 7c0-1.109-.891-2-2-2s-2 .891-2 2 .891 2 2 2 2-.891 2-2zm16.672 9c0 .531-.219 1.047-.578 1.406l-7.672 7.688c-.375.359-.891.578-1.422.578s-1.047-.219-1.406-.578L1.422 13.906C.625 13.125 0 11.609 0 10.5V4c0-1.094.906-2 2-2h6.5c1.109 0 2.625.625 3.422 1.422l11.172 11.156c.359.375.578.891.578 1.422zm6 0c0 .531-.219 1.047-.578 1.406l-7.672 7.688a2.08 2.08 0 0 1-1.422.578c-.812 0-1.219-.375-1.75-.922l7.344-7.344c.359-.359.578-.875.578-1.406s-.219-1.047-.578-1.422L14.422 3.422C13.625 2.625 12.11 2 11 2h3.5c1.109 0 2.625.625 3.422 1.422l11.172 11.156c.359.375.578.891.578 1.422z"/>
+</svg>
     <strong>Tags:</strong>&nbsp;
     <ul class="tags tags-small">
 
-        <li><a href="/en-US/docs/tag/Attribute">Attribute</a></li>
+        <li><a href="/en-US/docs/tag/Attribute" rel="nofollow">Attribute</a></li>
 
-        <li><a href="/en-US/docs/tag/HTML">HTML</a></li>
+        <li><a href="/en-US/docs/tag/Attributes" rel="nofollow">Attributes</a></li>
 
-        <li><a href="/en-US/docs/tag/Reference">Reference</a></li>
+        <li><a href="/en-US/docs/tag/Beginner" rel="nofollow">Beginner</a></li>
 
-        <li><a href="/en-US/docs/tag/R%C3%A9f%C3%A9rence">Référence</a></li>
+        <li><a href="/en-US/docs/tag/Configuring" rel="nofollow">Configuring</a></li>
 
-        <li><a href="/en-US/docs/tag/Web">Web</a></li>
+        <li><a href="/en-US/docs/tag/Element%20Attributes" rel="nofollow">Element Attributes</a></li>
+
+        <li><a href="/en-US/docs/tag/Elements" rel="nofollow">Elements</a></li>
+
+        <li><a href="/en-US/docs/tag/HTML" rel="nofollow">HTML</a></li>
+
+        <li><a href="/en-US/docs/tag/Reference" rel="nofollow">Reference</a></li>
+
+        <li><a href="/en-US/docs/tag/Settings" rel="nofollow">Settings</a></li>
+
+        <li><a href="/en-US/docs/tag/Web" rel="nofollow">Web</a></li>
 
     </ul>
   </div>
 
 
 
-                    <div class="contributors-sub">
-                      <i aria-hidden="true" class="icon-group icon-fw"></i>&nbsp;<strong>Contributors to this page:</strong>
-        <a href="/en-US/profiles/piglovesyou">piglovesyou</a>,
+                  <div class="contributors-sub">
+                    <svg class="icon icon-group" xmlns="http://www.w3.org/2000/svg" width="30" height="28" viewBox="0 0 30 28" aria-hidden="true">
+    <path d="M9.266 14a5.532 5.532 0 0 0-4.141 2H3.031C1.468 16 0 15.25 0 13.516 0 12.25-.047 8 1.937 8c.328 0 1.953 1.328 4.062 1.328.719 0 1.406-.125 2.078-.359A7.624 7.624 0 0 0 7.999 10c0 1.422.453 2.828 1.266 4zM26 23.953C26 26.484 24.328 28 21.828 28H8.172C5.672 28 4 26.484 4 23.953 4 20.422 4.828 15 9.406 15c.531 0 2.469 2.172 5.594 2.172S20.063 15 20.594 15C25.172 15 26 20.422 26 23.953zM10 4c0 2.203-1.797 4-4 4S2 6.203 2 4s1.797-4 4-4 4 1.797 4 4zm11 6c0 3.313-2.688 6-6 6s-6-2.688-6-6 2.688-6 6-6 6 2.688 6 6zm9 3.516C30 15.25 28.531 16 26.969 16h-2.094a5.532 5.532 0 0 0-4.141-2A7.066 7.066 0 0 0 22 10a7.6 7.6 0 0 0-.078-1.031A6.258 6.258 0 0 0 24 9.328C26.109 9.328 27.734 8 28.062 8c1.984 0 1.937 4.25 1.937 5.516zM28 4c0 2.203-1.797 4-4 4s-4-1.797-4-4 1.797-4 4-4 4 1.797 4 4z"/>
+</svg>
+                    <strong>Contributors to this page:</strong>
 
-        <a href="/en-US/profiles/jswisher">jswisher</a>,
+        <a href="/en-US/profiles/chrisdavidmills" rel="nofollow">chrisdavidmills</a>,
 
-        <a href="/en-US/profiles/leleofg">leleofg</a>,
+        <a href="/en-US/profiles/Malvoz" rel="nofollow">Malvoz</a>,
 
-        <a href="/en-US/profiles/Tigt">Tigt</a>,
+        <a href="/en-US/profiles/mdnwebdocs-bot" rel="nofollow">mdnwebdocs-bot</a>,
 
-        <a href="/en-US/profiles/Sheppy">Sheppy</a>,
+        <a href="/en-US/profiles/JonathanPool" rel="nofollow">JonathanPool</a>,
 
-        <a href="/en-US/profiles/myuller">myuller</a>,
+        <a href="/en-US/profiles/chharvey" rel="nofollow">chharvey</a>,
 
-        <a href="/en-US/profiles/rk17">rk17</a>,
+        <a href="/en-US/profiles/mfuji09" rel="nofollow">mfuji09</a>,
 
-        <a href="/en-US/profiles/louuis">louuis</a>,
+        <a href="/en-US/profiles/hrvoj3e" rel="nofollow">hrvoj3e</a>,
 
-        <a href="/en-US/profiles/George8211">George8211</a>,
+        <a href="/en-US/profiles/peterwilsoncc" rel="nofollow">peterwilsoncc</a>,
 
-        <a href="/en-US/profiles/estelle">estelle</a>,
+        <a href="/en-US/profiles/sideshowbarker" rel="nofollow">sideshowbarker</a>,
 
-        <a href="/en-US/profiles/klez">klez</a>,
+        <a href="/en-US/profiles/ntutangyun" rel="nofollow">ntutangyun</a>,
 
-        <a href="/en-US/profiles/kscarfone">kscarfone</a>,
+        <a href="/en-US/profiles/evilpie" rel="nofollow">evilpie</a>,
 
-        <a href="/en-US/profiles/Shokr">Shokr</a>,
+        <a href="/en-US/profiles/Sheppy" rel="nofollow">Sheppy</a>,
 
-        <a href="/en-US/profiles/Techsin">Techsin</a>,
+        <a href="/en-US/profiles/fvsch" rel="nofollow">fvsch</a>,
 
-        <a href="/en-US/profiles/haboqueferus">haboqueferus</a>,
+        <a href="/en-US/profiles/SphinxKnight" rel="nofollow">SphinxKnight</a>,
 
-        <a href="/en-US/profiles/evilpie">evilpie</a>,
+        <a href="/en-US/profiles/rudijuri" rel="nofollow">rudijuri</a>,
 
-        <a href="/en-US/profiles/Srggamer">Srggamer</a>,
+        <a href="/en-US/profiles/xgqfrms-GitHub" rel="nofollow">xgqfrms-GitHub</a>,
 
-        <a href="/en-US/profiles/lmorchard">lmorchard</a>,
+        <a href="/en-US/profiles/madmurphy" rel="nofollow">madmurphy</a>,
 
-        <a href="/en-US/profiles/shirayuki">shirayuki</a>,
+        <a href="/en-US/profiles/m59peacemaker" rel="nofollow">m59peacemaker</a>,
 
-        <a href="/en-US/profiles/jonathan.camenisch">jonathan.camenisch</a>,
+        <a href="/en-US/profiles/ChrisPermijo" rel="nofollow">ChrisPermijo</a>,
 
-        <a href="/en-US/profiles/tregagnon">tregagnon</a>,
+        <a href="/en-US/profiles/mfluehr" rel="nofollow">mfluehr</a>,
 
-        <a href="/en-US/profiles/Markus%20Prokott">Markus Prokott</a>,
+        <a href="/en-US/profiles/shubhamg931" rel="nofollow">shubhamg931</a>,
 
-        <a href="/en-US/profiles/McGurk">McGurk</a>,
+        <a href="/en-US/profiles/diervo" rel="nofollow">diervo</a>,
 
-        <a href="/en-US/profiles/masondesu">masondesu</a>,
+        <a href="/en-US/profiles/Kinifwyne" rel="nofollow">Kinifwyne</a>,
 
-        <a href="/en-US/profiles/hobophobe">hobophobe</a>,
+        <a href="/en-US/profiles/piglovesyou" rel="nofollow">piglovesyou</a>,
 
-        <a href="/en-US/profiles/fscholz">fscholz</a>,
+        <a href="/en-US/profiles/jswisher" rel="nofollow">jswisher</a>,
 
-        <a href="/en-US/profiles/thatryan">thatryan</a>,
+        <a href="/en-US/profiles/leleofg" rel="nofollow">leleofg</a>,
 
-        <a href="/en-US/profiles/garann">garann</a>
+        <a href="/en-US/profiles/Tigt" rel="nofollow">Tigt</a>,
 
-                    </div>
+        <a href="/en-US/profiles/myuller" rel="nofollow">myuller</a>,
+
+        <a href="/en-US/profiles/rk17" rel="nofollow">rk17</a>,
+
+        <a href="/en-US/profiles/louuis" rel="nofollow">louuis</a>,
+
+        <a href="/en-US/profiles/George8211" rel="nofollow">George8211</a>,
+
+        <a href="/en-US/profiles/estelle" rel="nofollow">estelle</a>,
+
+        <a href="/en-US/profiles/klez" rel="nofollow">klez</a>,
+
+        <a href="/en-US/profiles/kscarfone" rel="nofollow">kscarfone</a>,
+
+        <a href="/en-US/profiles/Shokr" rel="nofollow">Shokr</a>,
+
+        <a href="/en-US/profiles/Techsin" rel="nofollow">Techsin</a>,
+
+        <a href="/en-US/profiles/haboqueferus" rel="nofollow">haboqueferus</a>,
+
+        <a href="/en-US/profiles/Srggamer" rel="nofollow">Srggamer</a>,
+
+        <a href="/en-US/profiles/lmorchard" rel="nofollow">lmorchard</a>,
+
+        <a href="/en-US/profiles/shirayuki" rel="nofollow">shirayuki</a>,
+
+        <a href="/en-US/profiles/jonathan.camenisch" rel="nofollow">jonathan.camenisch</a>,
+
+        <a href="/en-US/profiles/tregagnon" rel="nofollow">tregagnon</a>,
+
+        <a href="/en-US/profiles/Markus%20Prokott" rel="nofollow">Markus Prokott</a>,
+
+        <a href="/en-US/profiles/McGurk" rel="nofollow">McGurk</a>,
+
+        <a href="/en-US/profiles/masondesu" rel="nofollow">masondesu</a>,
+
+        <a href="/en-US/profiles/hobophobe" rel="nofollow">hobophobe</a>,
+
+        <a href="/en-US/profiles/fscholz" rel="nofollow">fscholz</a>,
+
+        <a href="/en-US/profiles/thatryan" rel="nofollow">thatryan</a>,
+
+        <a href="/en-US/profiles/garann" rel="nofollow">garann</a>
+
+                  </div>
 
 
 
-                    <div class="contributors-sub">
-                      <i aria-hidden="true" class="icon-clock-o icon-fw"></i>&nbsp;<strong>Last updated by:</strong>
-                      <a href="/en-US/profiles/piglovesyou">piglovesyou</a>,
-                      <time datetime="2016-03-04T17:15:40-08:00">Mar 4, 2016, 5:15:40 PM</time>
-                    </div>
+                  <div class="contributors-sub">
+                    <svg class="icon icon-clock" xmlns="http://www.w3.org/2000/svg" width="24" height="28" viewBox="0 0 24 28" aria-hidden="true">
+    <path d="M14 8.5v7c0 .281-.219.5-.5.5h-5a.494.494 0 0 1-.5-.5v-1c0-.281.219-.5.5-.5H12V8.5c0-.281.219-.5.5-.5h1c.281 0 .5.219.5.5zm6.5 5.5c0-4.688-3.813-8.5-8.5-8.5S3.5 9.313 3.5 14s3.813 8.5 8.5 8.5 8.5-3.813 8.5-8.5zm3.5 0c0 6.625-5.375 12-12 12S0 20.625 0 14 5.375 2 12 2s12 5.375 12 12z"/>
+</svg>
+                    <strong>Last updated by:</strong>
+                    <a href="/en-US/profiles/chrisdavidmills" rel="nofollow">chrisdavidmills</a>,
+                    <time datetime="2019-05-13T00:54:20.434378-07:00">May 13, 2019, 12:54:20 AM</time>
+                  </div>
 
-                </div>
-
+              </div>
             </div>
 
+
+              <!-- quick links and approvals strip -->
+              <div id="wiki-left" class="column-strip wiki-column">
+
+                <!-- crumbs -->
+
+
+    <nav class="crumbs" role="navigation">
+      <ol typeof="BreadcrumbList" vocab="https://schema.org/" aria-label="breadcrumbs">
+
+          <li property="itemListElement" typeof="ListItem" class="crumb">
+            <a href="/en-US/docs/Web" property="item" typeof="WebPage">
+              <span property="name">Web technology for developers</span>
+            </a>
+            <meta property="position" content="1">
+          </li>
+
+          <li property="itemListElement" typeof="ListItem" class="crumb">
+            <a href="/en-US/docs/Web/HTML" property="item" typeof="WebPage">
+              <span property="name">HTML: Hypertext Markup Language</span>
+            </a>
+            <meta property="position" content="2">
+          </li>
+
+        <li property="itemListElement" typeof="ListItem" class="crumb">
+          <span property="name" aria-current="page">HTML attribute reference</span>
+        </li>
+      </ol>
+    </nav>
+
+
+
+                  <!-- quick links -->
+
+  <div class="quick-links" id="quick-links">
+    <div class="quick-links-head">Related Topics</div>
+
+ <ol>
+  <li><a href="/en-US/docs/Web/HTML"><strong><em>HTML</em></strong></a></li>
+  <li><strong>Tutorials:</strong></li>
+  <li><a href="/en-US/docs/Learn/Getting_started_with_the_web/HTML_basics">HTML basics</a></li>
+  <li class="toggle">
+    <details>
+      <summary>Introduction to HTML</summary>
+      <ol>
+          <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML">Introduction to HTML overview</a></li>
+          <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started">Getting started with HTML</a></li>
+          <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML">What's in the head? Metadata in HTML</a></li>
+          <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals">HTML text fundamentals</a></li>
+          <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks">Creating hyperlinks</a></li>
+          <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting">Advanced text formatting</a></li>
+          <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Document_and_website_structure">Document and website structure</a></li>
+          <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Debugging_HTML">Debugging HTML</a></li>
+          <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Marking_up_a_letter">Assessment: Marking up a letter</a></li>
+          <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content">Assessment: Structuring a page of content</a></li>
+      </ol>
+    </details>
+  </li>
+  <li class="toggle">
+    <details>
+      <summary>Multimedia and embedding</summary>
+      <ol>
+        <li><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding">Multimedia and embedding overview</a></li>
+        <li><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML">Images in HTML</a></li>
+        <li><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content">Video and audio content</a></li>
+        <li><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies">From object to iframe — other embedding technologies</a></li>
+        <li><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web">Adding vector graphics to the Web</a></li>
+        <li><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images">Responsive images</a></li>
+        <li><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page">Assessment: Mozilla splash page</a></li>
+      </ol>
+    </details>
+  </li>
+  <li><strong><a href="/en-US/docs/Web/HTML/Reference">References:</a></strong></li>
+  <li class="toggle">
+    <details>
+      <summary>HTML elements</summary>
+      <ol><li><a href="/en-US/docs/Web/HTML/Element/a" title="The HTML &lt;a> element (or anchor element), along with it's href attribute, creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL."><code>&lt;a&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/abbr" title="The HTML Abbreviation element (&lt;abbr>) represents an abbreviation or acronym; the optional title attribute can provide an expansion or description for the abbreviation."><code>&lt;abbr&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/acronym" title="The HTML Acronym Element (&lt;acronym>) allows authors to clearly indicate a sequence of characters that compose an acronym or abbreviation for a word. This element has been removed in HTML5. Use &lt;abbr> instead."><code>&lt;acronym&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/address" title="The HTML &lt;address> element indicates that the enclosed HTML provides contact information for a person or people, or for an organization."><code>&lt;address&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/applet" title="The obsolete HTML Applet Element (&lt;applet>) embeds a Java applet into the document; this element has been deprecated in favor of &lt;object>."><code>&lt;applet&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/area" title="The HTML &lt;area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a &lt;map> element."><code>&lt;area&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/article" title="The HTML &lt;article> element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable"><code>&lt;article&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/aside" title="The HTML &lt;aside> element represents a portion of a document whose content is only indirectly related to the document's main content."><code>&lt;aside&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/audio" title="The HTML &lt;audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream."><code>&lt;audio&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/b" title="The HTML Bring Attention To element (&lt;b>)  is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance."><code>&lt;b&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/base" title="The HTML &lt;base> element specifies the base URL to use for all relative URLs contained within a document. There can be only one &lt;base> element in a document."><code>&lt;base&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/basefont" title="The obsolete HTML Base Font element (&lt;basefont>) sets a default font face, size, and color for the other elements which are descended from its parent element."><code>&lt;basefont&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/bdi" title="The HTML Bidirectional Isolate element (&lt;bdi>)  tells the browser's bidirectional algorithm to treat the text it contains in isolation from its surrounding text."><code>&lt;bdi&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/bdo" title="The HTML Bidirectional Text Override element (&lt;bdo>) overrides the current directionality of text, so that the text within is rendered in a different direction."><code>&lt;bdo&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This API has not been standardized."><i class="icon-warning-sign"> </i></span></span><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/bgsound" title="The Internet Explorer only HTML Background Sound element (&lt;bgsound>) sets up a sound file to play in the background while the page is used; use &lt;audio> instead."><code>&lt;bgsound&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/big" title="The obsolete HTML Big Element (&lt;big>) renders the enclosed text at a font size one level larger than the surrounding text (medium becomes large, for example)."><code>&lt;big&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/blink" title="The HTML Blink Element (&lt;blink>) is a non-standard element which causes the enclosed text to flash slowly."><code>&lt;blink&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/blockquote" title="The HTML &lt;blockquote> Element (or HTML Block Quotation Element) indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the &lt;cite> element."><code>&lt;blockquote&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/body" title="The HTML &lt;body> Element represents the content of an HTML document. There can be only one &lt;body> element in a document."><code>&lt;body&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/br" title="The HTML &lt;br> element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant."><code>&lt;br&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/button" title="The HTML &lt;button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality."><code>&lt;button&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/canvas" title="Use the HTML &lt;canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations."><code>&lt;canvas&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/caption" title="The HTML Table Caption element (&lt;caption>) specifies the caption (or title) of a table, and if used is always the first child of a &lt;table>."><code>&lt;caption&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/center" title="The obsolete HTML Center Element (&lt;center>) is a block-level element that displays its block-level or inline contents centered horizontally within its containing element."><code>&lt;center&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/cite" title="The HTML Citation element (&lt;cite>) is used to describe a reference to a cited creative work, and must include the title of that work."><code>&lt;cite&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/code" title="The HTML &lt;code> element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code."><code>&lt;code&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/col" title="The HTML &lt;col> element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a &lt;colgroup> element."><code>&lt;col&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/colgroup" title="The HTML &lt;colgroup> element defines a group of columns within a table."><code>&lt;colgroup&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/command" title="The HTML Command element (&lt;command>) represents a command which the user can invoke. Commands are often used as part of a context menu or toolbar."><code>&lt;command&gt;</code></a></li><li><span class="sidebar-icon"><span title="This deprecated API should no longer be used, but will probably still work."><i class="icon-thumbs-down-alt"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/content" title="The HTML &lt;content> element—an obsolete part of the Web Components suite of technologies—was used inside of Shadow DOM as an insertion point, and wasn't meant to be used in ordinary HTML."><code>&lt;content&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/data" title="The HTML &lt;data> element links a given content with a machine-readable translation. If the content is time- or date-related, the &lt;time> element must be used."><code>&lt;data&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/datalist" title="The HTML &lt;datalist> element contains a set of &lt;option> elements that represent the values available for other controls."><code>&lt;datalist&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/dd" title="The HTML &lt;dd> element provides the details about or the definition of the preceding term (&lt;dt>) in a description list (&lt;dl>)."><code>&lt;dd&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/del" title="The HTML &lt;del> element represents a range of text that has been deleted from a document."><code>&lt;del&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/details" title='The HTML Details Element (&lt;details>) creates a disclosure widget in which information is visible only when the widget is toggled into an "open" state.'><code>&lt;details&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/dfn" title="The HTML Definition element (&lt;dfn>) is used to indicate the term being defined within the context of a definition phrase or sentence."><code>&lt;dfn&gt;</code></a></li><li><span class="sidebar-icon"><span title="This is an experimental API that should not be used in production code."><i class="icon-beaker"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/dialog" title="The HTML &lt;dialog> element represents a dialog box or other interactive component, such as an inspector or window."><code>&lt;dialog&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/dir" title="The obsolete HTML Directory element (&lt;dir>) is used as a container for a directory of files and/or folders, potentially with styles and icons applied by the user agent."><code>&lt;dir&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/div" title="The HTML Content Division element (&lt;div>) is the generic container for flow content. It has no effect on the content or layout until styled using CSS."><code>&lt;div&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/dl" title="The HTML &lt;dl> element represents a description list. The element encloses a list of groups of terms (specified using the &lt;dt> element) and descriptions (provided by &lt;dd> elements). Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs)."><code>&lt;dl&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/dt" title="The HTML &lt;dt> element specifies a term in a description or definition list, and as such must be used inside a &lt;dl> element."><code>&lt;dt&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/element" title="The obsolete HTML &lt;element> element was part of the Web Components specification; it was intended to be used to define new custom DOM elements."><code>&lt;element&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/em" title="The HTML &lt;em> element marks text that has stress emphasis. The &lt;em> element can be nested, with each level of nesting indicating a greater degree of emphasis."><code>&lt;em&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/embed" title="The HTML &lt;embed> element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in."><code>&lt;embed&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/fieldset" title="The HTML &lt;fieldset> element is used to group several controls as well as labels (&lt;label>) within a web form."><code>&lt;fieldset&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/figcaption" title="The HTML &lt;figcaption> or Figure Caption element represents a caption or legend describing the rest of the contents of its parent &lt;figure> element."><code>&lt;figcaption&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/figure" title="The HTML &lt;figure> (Figure With Optional Caption) element represents self-contained content, potentially with an optional caption, which is specified using the (&lt;figcaption>) element."><code>&lt;figure&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/font" title="The HTML Font Element (&lt;font>) defines the font size, color and face for its content."><code>&lt;font&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/footer" title="The HTML &lt;footer> element represents a footer for its nearest sectioning content or sectioning root element. A footer typically contains information about the author of the section, copyright data or links to related documents."><code>&lt;footer&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/form" title="The HTML &lt;form> element represents a document section that contains interactive controls for submitting information to a web server."><code>&lt;form&gt;</code></a></li><li><span class="sidebar-icon"><span title="This deprecated API should no longer be used, but will probably still work."><i class="icon-thumbs-down-alt"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/frame" title="&lt;frame> is an HTML element which defines a particular area in which another HTML document can be displayed. A frame should be used within a &lt;frameset>."><code>&lt;frame&gt;</code></a></li><li><span class="sidebar-icon"><span title="This deprecated API should no longer be used, but will probably still work."><i class="icon-thumbs-down-alt"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/frameset" title="The HTML &lt;frameset> element is used to contain &lt;frame> elements."><code>&lt;frameset&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements" title="The HTML &lt;h1>–&lt;h6> elements represent six levels of section headings. &lt;h1> is the highest section level and &lt;h6> is the lowest."><code>&lt;h1&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/head" title="The HTML &lt;head> element contains machine-readable information (metadata) about the document, like its title, scripts, and style sheets."><code>&lt;head&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/header" title="The HTML &lt;header> element represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also a logo, a search form, an author name, and other elements."><code>&lt;header&gt;</code></a></li><li><span class="sidebar-icon"><span title="This is an experimental API that should not be used in production code."><i class="icon-beaker"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/hgroup" title="The HTML &lt;hgroup> element represents a multi-level heading for a section of a document. It groups a set of &lt;h1>–&lt;h6> elements."><code>&lt;hgroup&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/hr" title="The HTML &lt;hr> element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section."><code>&lt;hr&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/html" title="The HTML &lt;html> element represents the root (top-level element) of an HTML document, so it is also referred to as the root element. All other elements must be descendants of this element."><code>&lt;html&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/i" title="The HTML &lt;i> element represents a range of text that is set off from the normal text for some reason. Some examples include technical terms, foreign language phrases, or fictional character thoughts. It is typically displayed in italic type."><code>&lt;i&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/iframe" title="The HTML Inline Frame element (&lt;iframe>) represents a nested browsing context, embedding another HTML page into the current one."><code>&lt;iframe&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This API has not been standardized."><i class="icon-warning-sign"> </i></span></span><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/image" title="The obsolete HTML Image element (&lt;image>) is an obsolete remnant of an ancient version of HTML lost in the mists of time; use the standard &lt;img> element instead."><code>&lt;image&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/img" title="The HTML &lt;img> element embeds an image into the document. It is a replaced element."><code>&lt;img&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input" title="The HTML &lt;input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."><code>&lt;input&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/ins" title="The HTML &lt;ins> element represents a range of text that has been added to a document."><code>&lt;ins&gt;</code></a></li><li><span class="sidebar-icon"><span title="This deprecated API should no longer be used, but will probably still work."><i class="icon-thumbs-down-alt"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/isindex" title="&lt;isindex> is an obsolete HTML element that puts a text field in a page for querying the document."><code>&lt;isindex&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/kbd" title="The HTML Keyboard Input element (&lt;kbd>) represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device."><code>&lt;kbd&gt;</code></a></li><li><span class="sidebar-icon"><span title="This deprecated API should no longer be used, but will probably still work."><i class="icon-thumbs-down-alt"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/keygen" title="The HTML &lt;keygen> element exists to facilitate generation of key material, and submission of the public key as part of an HTML form. This mechanism is designed for use with Web-based certificate management systems. It is expected that the &lt;keygen> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate."><code>&lt;keygen&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/label" title="The HTML &lt;label> element represents a caption for an item in a user interface."><code>&lt;label&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/legend" title="The HTML &lt;legend> element represents a caption for the content of its parent &lt;fieldset>."><code>&lt;legend&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/li" title="The HTML &lt;li> element is used to represent an item in a list. It must be contained in a parent element: an ordered list (&lt;ol>), an unordered list (&lt;ul>), or a menu (&lt;menu>). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter."><code>&lt;li&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/link" title='The HTML External Resource Link element (&lt;link>) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and mobile home screen/app icons) among other things.'><code>&lt;link&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/listing" title="The HTML Listing Element (&lt;listing>) renders text between the start and end tags without interpreting the HTML in between and using a monospaced font. The HTML 2 standard recommended that lines shouldn't be broken when not greater than 132 characters."><code>&lt;listing&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/main" title="The HTML &lt;main> element represents the dominant content of the &lt;body> of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application."><code>&lt;main&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/map" title="The HTML &lt;map> element is used with &lt;area> elements to define an image map (a clickable link area)."><code>&lt;map&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/mark" title="The HTML Mark Text element (&lt;mark>) represents text which is marked or highlighted for reference or notation purposes, due to the marked passage's relevance or importance in the enclosing context."><code>&lt;mark&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/marquee" title="The HTML &lt;marquee> element is used to insert a scrolling area of text. You can control what happens when the text reaches the edges of its content area using its attributes."><code>&lt;marquee&gt;</code></a></li><li><span class="sidebar-icon"><span title="This is an experimental API that should not be used in production code."><i class="icon-beaker"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/menu" title="The HTML &lt;menu> element represents a group of commands that a user can perform or activate. This includes both list menus, which might appear across the top of a screen, as well as context menus, such as those that might appear underneath a button after it has been clicked."><code>&lt;menu&gt;</code></a></li><li><span class="sidebar-icon"><span title="This deprecated API should no longer be used, but will probably still work."><i class="icon-thumbs-down-alt"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/menuitem" title="The HTML &lt;menuitem> element represents a command that a user is able to invoke through a popup menu. This includes context menus, as well as menus that might be attached to a menu button."><code>&lt;menuitem&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/meta" title="The HTML &lt;meta> element represents metadata that cannot be represented by other HTML meta-related elements, like &lt;base>, &lt;link>, &lt;script>, &lt;style> or &lt;title>."><code>&lt;meta&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/meter" title="The HTML &lt;meter> element represents either a scalar value within a known range or a fractional value."><code>&lt;meter&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This API has not been standardized."><i class="icon-warning-sign"> </i></span></span><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/multicol" title="The HTML Multi-Column Layout element (&lt;multicol>) was an experimental element designed to allow multi-column layouts and must not be used."><code>&lt;multicol&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/nav" title="The HTML &lt;nav> element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes."><code>&lt;nav&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/nextid" title="&lt;nextid> is an obsolete HTML element that served to enable the NeXT web designing tool to generate automatic NAME labels for its anchors."><code>&lt;nextid&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This API has not been standardized."><i class="icon-warning-sign"> </i></span></span><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/nobr" title="The non-standard, obsolete HTML &lt;nobr> element prevents the text it contains from automatically wrapping across multiple lines, potentially resulting in the user having to scroll horizontally to see the entire width of the text."><code>&lt;nobr&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This API has not been standardized."><i class="icon-warning-sign"> </i></span></span><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/noembed" title='The &lt;noembed> element is an obsolete, non-standard way to provide alternative, or "fallback", content for browsers that do not support the &lt;embed> element or do not support the type of embedded content an author wishes to use.'><code>&lt;noembed&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/noframes" title="The obsolete HTML No Frames or frame fallback element, &lt;noframes>, provides content to be presented in browsers that don't support (or have disabled support for) the &lt;frame> element."><code>&lt;noframes&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/noscript" title="The HTML &lt;noscript> element defines a section of HTML to be inserted if a script type on the page is unsupported or if scripting is currently turned off in the browser."><code>&lt;noscript&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/object" title="The HTML &lt;object> element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."><code>&lt;object&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/ol" title="The HTML &lt;ol> element represents an ordered list of items, typically rendered as a numbered list."><code>&lt;ol&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/optgroup" title="The HTML &lt;optgroup> element creates a grouping of options within a &lt;select> element."><code>&lt;optgroup&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/option" title="The HTML &lt;option> element is used to define an item contained in a &lt;select>, an &lt;optgroup>, or a &lt;datalist> element. As such, &lt;option> can represent menu items in popups and other lists of items in an HTML document."><code>&lt;option&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/output" title="The HTML Output element (&lt;output>) is a container element into which a site or app can inject the results of a calculation or the outcome of a user action."><code>&lt;output&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/p" title="The HTML &lt;p> element represents a paragraph."><code>&lt;p&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/param" title="The HTML &lt;param> element defines parameters for an &lt;object> element."><code>&lt;param&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/picture" title="The HTML &lt;picture> element contains zero or more &lt;source> elements and one &lt;img> element to provide versions of an image for different display/device scenarios."><code>&lt;picture&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/plaintext" title="The HTML Plaintext Element (&lt;plaintext>) renders everything following the start tag as raw text, ignoring any following HTML."><code>&lt;plaintext&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/pre" title="The HTML &lt;pre> element represents preformatted text which is to be presented exactly as written in the HTML file."><code>&lt;pre&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/progress" title="The HTML &lt;progress> element displays an indicator showing the completion progress of a task, typically displayed as a progress bar."><code>&lt;progress&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/q" title="The HTML &lt;q> element  indicates that the enclosed text is a short inline quotation. Most modern browsers implement this by surrounding the text in quotation marks. "><code>&lt;q&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/rb" title="The HTML Ruby Base (&lt;rb>) element is used to delimit the base text component of a  &lt;ruby> annotation, i.e. the text that is being annotated."><code>&lt;rb&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/rp" title="The HTML Ruby Fallback Parenthesis (&lt;rp>) element is used to provide fall-back parentheses for browsers that do not support display of ruby annotations using the &lt;ruby> element."><code>&lt;rp&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/rt" title="The HTML Ruby Text (&lt;rt>) element specifies the ruby text component of a ruby annotation, which is used to provide pronunciation, translation, or transliteration information for East Asian typography. The &lt;rt> element must always be contained within a &lt;ruby> element."><code>&lt;rt&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/rtc" title="The HTML Ruby Text Container (&lt;rtc>) element embraces semantic annotations of characters presented in a ruby of &lt;rb> elements used inside of &lt;ruby> element. &lt;rb> elements can have both pronunciation (&lt;rt>) and semantic (&lt;rtc>) annotations."><code>&lt;rtc&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/ruby" title="The HTML &lt;ruby> element represents a ruby annotation. Ruby annotations are for showing pronunciation of East Asian characters."><code>&lt;ruby&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/s" title="The HTML &lt;s> element renders text with a strikethrough, or a line through it. Use the &lt;s> element to represent things that are no longer relevant or no longer accurate. However, &lt;s> is not appropriate when indicating document edits; for that, use the &lt;del> and &lt;ins> elements, as appropriate."><code>&lt;s&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/samp" title="The HTML Sample Element (&lt;samp>) is used to enclose inline text which represents sample (or quoted) output from a computer program."><code>&lt;samp&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/script" title="The HTML &lt;script> element is used to embed or reference executable code; this is typically used to embed or refer to JavaScript code."><code>&lt;script&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/section" title="The HTML &lt;section> element represents a standalone section — which doesn't have a more specific semantic element to represent it — contained within an HTML document."><code>&lt;section&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/select" title="The HTML &lt;select> element represents a control that provides a menu of options"><code>&lt;select&gt;</code></a></li><li><span class="sidebar-icon"><span title="This deprecated API should no longer be used, but will probably still work."><i class="icon-thumbs-down-alt"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/shadow" title="The HTML &lt;shadow> element—an obsolete part of the Web Components technology suite—was intended to be used as a shadow DOM insertion point."><code>&lt;shadow&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/slot" title="The HTML &lt;slot> element—part of the Web Components technology suite—is a placeholder inside a web component that you can fill with your own markup, which lets you create separate DOM trees and present them together."><code>&lt;slot&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/small" title="The HTML &lt;small> element makes the text font size one size smaller (for example, from large to medium, or from small to x-small) down to the browser's minimum font size.  In HTML5, this element is repurposed to represent side-comments and small print, including copyright and legal text, independent of its styled presentation."><code>&lt;small&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/source" title="The HTML &lt;source> element specifies multiple media resources for the &lt;picture>, the &lt;audio> element, or the &lt;video> element."><code>&lt;source&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/spacer" title="&lt;spacer> is an obsolete HTML element which allowed insertion of empty spaces on pages. It was devised by Netscape to accomplish the same effect as a single-pixel layout image, which was something web designers used to use to add white spaces to web pages without actually using an image. However, &lt;spacer> no longer supported by any major browser and the same effects can now be achieved using simple CSS. "><code>&lt;spacer&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/span" title="The HTML &lt;span> element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang."><code>&lt;span&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/strike" title="The HTML &lt;strike> element (or HTML Strikethrough Element) places a strikethrough (horizontal line) over text."><code>&lt;strike&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/strong" title="The HTML Strong Importance Element (&lt;strong>) indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type."><code>&lt;strong&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/style" title="The HTML &lt;style> element contains style information for a document, or part of a document."><code>&lt;style&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/sub" title="The HTML Subscript element (&lt;sub>) specifies inline text which should be displayed as subscript for solely typographical reasons."><code>&lt;sub&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/summary" title="The HTML Disclosure Summary element (&lt;summary>) element specifies a summary, caption, or legend for a &lt;details> element's disclosure box."><code>&lt;summary&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/sup" title="The HTML Superscript element (&lt;sup>) specifies inline text which is to be displayed as superscript for solely typographical reasons."><code>&lt;sup&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/table" title="The HTML &lt;table> element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data."><code>&lt;table&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/tbody" title="The HTML Table Body element (&lt;tbody>) encapsulates a set of table rows (&lt;tr> elements), indicating that they comprise the body of the table (&lt;table>)."><code>&lt;tbody&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/td" title="The HTML &lt;td> element defines a cell of a table that contains data. It participates in the table model."><code>&lt;td&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/template" title="The HTML Content Template (&lt;template>) element is a mechanism for holding HTML that is not to be rendered immediately when a page is loaded but may be instantiated subsequently during runtime using JavaScript."><code>&lt;template&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/textarea" title="The HTML &lt;textarea> element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form."><code>&lt;textarea&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/tfoot" title="The HTML &lt;tfoot> element defines a set of rows summarizing the columns of the table."><code>&lt;tfoot&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/th" title="The HTML &lt;th> element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes."><code>&lt;th&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/thead" title="The HTML &lt;thead> element defines a set of rows defining the head of the columns of the table."><code>&lt;thead&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/time" title="The HTML &lt;time> element represents a specific period in time."><code>&lt;time&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/title" title="The HTML Title element (&lt;title>) defines the document's title that is shown in a browser's title bar or a page's tab."><code>&lt;title&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/tr" title="The HTML &lt;tr> element defines a row of cells in a table. The row's cells can then be established using a mix of &lt;td> (data cell) and &lt;th> (header cell) elements.The HTML &lt;tr> element specifies that the markup contained inside the &lt;tr> block comprises one row of a table, inside which the &lt;th> and &lt;td> elements create header and data cells, respectively, within the row."><code>&lt;tr&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/track" title="The HTML &lt;track> element is used as a child of the media elements &lt;audio> and &lt;video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks or Timed Text Markup Language (TTML)."><code>&lt;track&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/tt" title="The obsolete HTML Teletype Text element (&lt;tt>) creates inline text which is presented using the user agent's default monospace font face."><code>&lt;tt&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/u" title="The HTML Unarticulated Annotation Element (&lt;u>) represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation."><code>&lt;u&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/ul" title="The HTML &lt;ul> element represents an unordered list of items, typically rendered as a bulleted list."><code>&lt;ul&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/var" title="The HTML Variable element (&lt;var>) represents the name of a variable in a mathematical expression or a programming context."><code>&lt;var&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/video" title="The HTML Video element (&lt;video>) embeds a media player which supports video playback into the document."><code>&lt;video&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/wbr" title="The HTML &lt;wbr> element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location."><code>&lt;wbr&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/xmp" title="The HTML Example Element (&lt;xmp>) renders text between the start and end tags without interpreting the HTML in between and using a monospaced font. The HTML2 specification recommended that it should be rendered wide enough to allow 80 characters per line."><code>&lt;xmp&gt;</code></a></li></ol>
+    </details>
+  </li>
+  <li class="toggle">
+    <details>
+      <summary>Global attributes</summary>
+      <ol><li><a href="/en-US/docs/Web/HTML/Global_attributes/accesskey" title="The accesskey global attribute provides a hint for generating a keyboard shortcut for the current element. The attribute value must consist of a single printable character (which includes accented and other characters that can be generated by the keyboard)."><code>accesskey</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/autocapitalize" title="The autocapitalize global attribute is an enumerated attribute that controls whether and how text input is automatically capitalized as it is entered/edited by the user."><code>autocapitalize</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/class" title="The class global attribute is a space-separated list of the classes of the element. Classes allow CSS and Javascript to select and access specific elements via the class selectors or functions like the DOM method document.getElementsByClassName."><code>class</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/contenteditable" title="The contenteditable global attribute is an enumerated attribute indicating if the element should be editable by the user. If so, the browser modifies its widget to allow editing."><code>contenteditable</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/contextmenu" title="The contextmenu global attribute is the id of a &lt;menu> to use as the contextual menu for this element."><code>contextmenu</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/data-*" title="The data-* global attributes form a class of attributes called custom data attributes, that allow proprietary information to be exchanged between the HTML and its DOM representation by scripts."><code>data-*</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/dir" title="The dir global attribute is an enumerated attribute indicates the directionality of the element's text."><code>dir</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/draggable" title="The draggable global attribute is an enumerated attribute that indicates whether the element can be dragged, either with native browser behavior or the HTML Drag and Drop API."><code>draggable</code></a></li><li><span class="sidebar-icon"><span title="This is an experimental API that should not be used in production code."><i class="icon-beaker"> </i></span></span><a href="/en-US/docs/Web/HTML/Global_attributes/dropzone" title="The dropzone global attribute is an enumerated attribute indicating what types of content can be dropped on an element, using the HTML Drag and Drop API. It can have the following values:"><code>dropzone</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/hidden" title="The hidden global attribute is a Boolean attribute indicating that the element is not yet, or is no longer, relevant. For example, it can be used to hide elements of the page that can't be used until the login process has been completed."><code>hidden</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/id" title="The id global attribute defines an identifier (ID) which must be unique in the whole document. Its purpose is to identify the element when linking (using a fragment identifier), scripting, or styling (with CSS)."><code>id</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/inputmode" title="The inputmode global attribute is an enumerated attribute that provides a hint as to the type of data that might be entered by the user while editing the element or its contents."><code>inputmode</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/is" title="The is global attribute allows you to specify that a standard HTML element should behave like a defined custom built-in element (see Using custom elements for more details)."><code>is</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/itemid" title="The itemid global attribute provides microdata in the form of a unique, global identifier of an item."><code>itemid</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/itemprop" title="The itemprop global attribute is used to add properties to an item. Every HTML element can have an itemprop attribute specified, and an itemprop consists of a name-value pair. Each name-value pair is called a property, and a group of one or more properties forms an item. Property values are either a string or a URL and can be associated with a very wide range of elements including &lt;audio>, &lt;embed>, &lt;iframe>, &lt;img>, &lt;link>, &lt;object>, &lt;source> , &lt;track>, and &lt;video>."><code>itemprop</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/itemref" title="Properties that are not descendants of an element with the itemscope attribute can be associated with an item using the global attribute itemref."><code>itemref</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/itemscope" title="itemscope is a boolean global attribute that defines the scope of associated metadata. Specifying the itemscope attribute for an element creates a new item, which results in a number of name-value pairs that are associated with the element."><code>itemscope</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/itemtype" title="The global attribute itemtype specifies the URL of the vocabulary that will be used to define itemprop's (item properties) in the data structure. "><code>itemtype</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/lang" title="The lang global attribute helps define the language of an element: the language that non-editable elements are written in, or the language that the editable elements should be written in by the user. The attribute contains a single “language tag” in the format defined in Tags for Identifying Languages (BCP47)."><code>lang</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/slot" title="The slot global attribute assigns a slot in a shadow DOM shadow tree to an element: An element with a slot attribute is assigned to the slot created by the &lt;slot> element whose name attribute's value matches that slot attribute's value."><code>slot</code></a></li><li><span class="sidebar-icon"><span title="This is an experimental API that should not be used in production code."><i class="icon-beaker"> </i></span></span><a href="/en-US/docs/Web/HTML/Global_attributes/spellcheck" title="The spellcheck global attribute is an enumerated attribute defines whether the element may be checked for spelling errors."><code>spellcheck</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/style" title="The style global attribute contains CSS styling declarations to be applied to the element. Note that it is recommended for styles to be defined in a separate file or files. This attribute and the &lt;style> element have mainly the purpose of allowing for quick styling, for example for testing purposes."><code>style</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/tabindex" title="The tabindex global attribute indicates if its element can be focused, and if/where it participates in sequential keyboard navigation (usually with the Tab key, hence the name)."><code>tabindex</code></a></li><li><a href="/en-US/docs/Web/HTML/Global_attributes/title" title="The title global attribute contains text representing advisory information related to the element it belongs to."><code>title</code></a></li><li><span class="sidebar-icon"><span title="This is an experimental API that should not be used in production code."><i class="icon-beaker"> </i></span></span><a href="/en-US/docs/Web/HTML/Global_attributes/translate" title="The translate global attribute is an enumerated attribute that is used to specify whether an element's translateable attribute values and its Text node children should be translated when the page is localized, or whether to leave them unchanged."><code>translate</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This API has not been standardized."><i class="icon-warning-sign"> </i></span></span><a href="/en-US/docs/Web/HTML/Global_attributes/x-ms-acceleratorkey" title="The x-ms-acceleratorkey property provides a way to declare that an accelerator key has been assigned to an element."><code>x-ms-acceleratorkey</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This API has not been standardized."><i class="icon-warning-sign"> </i></span></span><a href="/en-US/docs/Web/HTML/Global_attributes/x-ms-format-detection" title="The x-ms-format-detection attribute determines whether data formats within content are automatically detected and converted to clickable links."><code>x-ms-format-detection</code></a></li></ol>
+    </details>
+  </li>
+  <li class="toggle">
+    <details>
+      <summary><code>&lt;input&gt;</code> types</summary>
+      <ol><li><a href="/en-US/docs/Web/HTML/Element/input/button" title="&lt;input> elements of type button are rendered as simple push buttons, which can be programmed to control custom functionality anywhere on a webpage as required when assigned an event handler function (typically for the click event)."><code>&lt;input type="button"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/checkbox" title="&lt;input> elements of type checkbox are rendered by default as square boxes that are checked (ticked) when activated, like you might see in an official government paper form. They allow you to select single values for submission in a form (or not)."><code>&lt;input type="checkbox"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/color" title='&lt;input> elements of type "color" provide a user interface element that lets a user specify a color, either by using a visual color picker interface or by entering the color into a text field in "#rrggbb" hexadecimal format.'><code>&lt;input type="color"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/date" title="&lt;input> elements of type date create input fields that let the user enter a date, either using a text box that automatically validates the content, or using a special date picker interface."><code>&lt;input type="date"&gt;</code></a></li><li><span class="sidebar-icon"><span class="icon-only-inline" title="This is an obsolete API and is no longer guaranteed to work."><i class="icon-trash"> </i></span></span><a href="/en-US/docs/Web/HTML/Element/input/datetime" title='The HTML &lt;input type="datetime"> was a control for entering a date and time (hour, minute, second, and fraction of a second) as well as a timezone. This feature has been removed from WHATWG HTML, and is no longer supported in browsers.'><code>&lt;input type="datetime"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/datetime-local" title="&lt;input> elements of type datetime-local create input controls that let the user easily enter both a date and a time, including the year, month, and day as well as the time in hours and minutes."><code>&lt;input type="datetime-local"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/email" title="&lt;input> elements of type email are used to let the user enter and edit an e-mail address, or, if the multiple attribute is specified, a list of e-mail addresses."><code>&lt;input type="email"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/file" title='&lt;input> elements with type="file" let the user choose one or more files from their device storage. Once chosen, the files can be uploaded to a server using form submission, or manipulated using JavaScript code and the File API.'><code>&lt;input type="file"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/hidden" title="&lt;input> elements of type &quot;hidden&quot; let web developers include data that cannot be seen or modified by users when a form is submitted. For example, the ID of the content that is currently being ordered or edited, or a unique security token. Hidden inputs are completely invisible in the rendered page, and there is no way to make it visible in the page's content."><code>&lt;input type="hidden"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/image" title="&lt;input> elements of type image are used to create graphical submit buttons, i.e. submit buttons that take the form of an image rather than text."><code>&lt;input type="image"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/month" title='&lt;input> elements of type month create input fields that let the user enter a month and year allowing a month and year to be easily entered. The value is a string whose value is in the format "YYYY-MM", where YYYY is the four-digit year and MM is the month number.'><code>&lt;input type="month"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/number" title="&lt;input> elements of type number are used to let the user enter a number. They include built-in validation to reject non-numerical entries."><code>&lt;input type="number"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/password" title="&lt;input> elements of type password provide a way for the user to securely enter a password."><code>&lt;input type="password"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/radio" title="&lt;input> elements of type radio are generally used in radio groups—collections of radio buttons describing a set of related options."><code>&lt;input type="radio"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/range" title="&lt;input> elements of type range let the user specify a numeric value which must be no less than a given value, and no more than another given value. The precise value, however, is not considered important. This is typically represented using a slider or dial control rather than a text entry box like the number input type."><code>&lt;input type="range"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/reset" title='&lt;input> elements of type "reset"  are rendered as buttons, with a default click event handler that resets all of the inputs in the form to their initial values.'><code>&lt;input type="reset"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/search" title="&lt;input> elements of type search are text fields designed for the user to enter search queries into. These are functionally identical to text inputs, but may be styled differently by the user agent. "><code>&lt;input type="search"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/submit" title="&lt;input> elements of type submit are rendered as buttons. When the click event occurs (typically because the user clicked the button), the user agent attempts to submit the form to the server."><code>&lt;input type="submit"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/tel" title='&lt;input> elements of type tel are used to let the user enter and edit a telephone number. Unlike &lt;input type="email"> and &lt;input type="url"> , the input value is not automatically validated to a particular format before the form can be submitted, because formats for telephone numbers vary so much around the world.'><code>&lt;input type="tel"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/text" title="&lt;input> elements of type text create basic single-line text fields."><code>&lt;input type="text"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/time" title="&lt;input> elements of type time create input fields designed to let the user easily enter a time (hours and minutes, and optionally seconds)."><code>&lt;input type="time"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/url" title="&lt;input> elements of type url are used to let the user enter and edit a URL."><code>&lt;input type="url"&gt;</code></a></li><li><a href="/en-US/docs/Web/HTML/Element/input/week" title="&lt;input> elements of type week create input fields allowing easy entry of a year plus the ISO 8601 week number during that year (i.e., week 1 to 52 or 53)."><code>&lt;input type="week"&gt;</code></a></li></ol>
+    </details>
+  </li>
+  <li><strong><a href="/en-US/docs/MDN">Documentation:</a></strong></li>
+  <li class="toggle">
+    <details>
+      <summary>Useful lists</summary>
+      <li><a href="/en-US/docs/Web/HTML/Index">All pages index</a></li>
+      <li><a href="/en-US/docs/tag/HTML">Pages tagged "HTML"</a></li>
+    </details>
+  </li>
+  <li class="toggle">
+    <details>
+      <summary>Contribute</summary>
+      <ol>
+        <li><a href="/en-US/docs/MDN/Doc_status/HTML">HTML doc status</a></li>
+        <li><a href="/en-US/docs/MDN">The MDN project</a></li>
+      </ol>
+    </details>
+  </li>
+ </ol>
+
+  </div>
+
+
+                <!-- approvals -->
+
+
+              </div>
 
           </div>
         </div>
       </div>
     </div> <!-- ends "main-content" -->
 
+
+      <div class="newsletter-box">
+        <div class="newsletter">
+    <form id="newsletterForm" class="newsletter-form nodisable" name="newsletter-form" action="https://www.mozilla.org/en-US/newsletter/" method="post">
+        <div class="newsletter-head">
+            <h2 class="newsletter-teaser">Learn the best of web development</h2>
+            <p class="newsletter-description">Get the latest and greatest from MDN delivered straight to your inbox.</p>
+
+        </div>
+
+        <div class="newsletter-fields">
+            <input type="hidden" id="fmt" name="fmt" value="H">
+            <input type="hidden" id="newsletterNewslettersInput" name="newsletters" value="app-dev" />
+            <div id="newsletterErrors" class="newsletter-errors"></div>
+
+            <div id="newsletterEmail" class="form-group newsletter-group-email">
+                <label for="newsletterEmailInput" class="form-label offscreen">E-mail</label>
+                <input type="email" id="newsletterEmailInput" name="email" class="form-input newsletter-input-email" required placeholder="you@example.com" size="30">
+            </div>
+
+            <div id="newsletterPrivacy" class="form-group form-group-agree newsletter-group-privacy hidden">
+                <input type="checkbox" id="newsletterPrivacyInput" name="privacy" required>
+                <label for="newsletterPrivacyInput">
+                I'm okay with Mozilla handling my info as explained in this <a href="https://www.mozilla.org/privacy/">Privacy Policy</a>.
+                </label>
+            </div>
+            <div id="newsletterSubmit" class="newsletter-group-submit">
+                <button id="newsletter-submit" type="submit" class="button neutral newsletter-submit">
+                    Sign up now<svg class="icon icon-arrow" xmlns="http://www.w3.org/2000/svg" width="23" height="28" viewBox="0 0 23 28" aria-hidden="true">
+    <path d="M23 15a2.01 2.01 0 0 1-.578 1.422L12.25 26.594c-.375.359-.891.578-1.422.578s-1.031-.219-1.406-.578L8.25 25.422c-.375-.375-.594-.891-.594-1.422s.219-1.047.594-1.422L12.828 18h-11C.703 18 0 17.062 0 16v-2c0-1.062.703-2 1.828-2h11L8.25 7.406a1.96 1.96 0 0 1 0-2.812l1.172-1.172c.375-.375.875-.594 1.406-.594s1.047.219 1.422.594l10.172 10.172c.375.359.578.875.578 1.406z"/>
+</svg>
+                </button>
+            </div>
+        </div>
+    </form>
+    <div id="newsletterThanks" class="newsletter-thanks hidden">
+        <h2>Thanks! Please check your inbox to confirm your subscription.</h2>
+        <p>If you haven’t previously confirmed a subscription to a Mozilla-related newsletter you may have to do so. Please check your inbox or your spam filter for an email from us.
+        </p>
+    </div>
+    <button id="newsletterHide" type="button" class="only-icon newsletter-hide hidden">
+        <span>Hide Newsletter Sign-up</span>
+        <svg class="icon icon-close" xmlns="http://www.w3.org/2000/svg" width="22" height="28" viewBox="0 0 22 28" aria-hidden="true" role="img"><title></title><path d="M20.281 20.656c0 .391-.156.781-.438 1.062l-2.125 2.125c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438L11 19.249l-4.594 4.594c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438l-2.125-2.125c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062L6.751 15l-4.594-4.594c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062l2.125-2.125c.281-.281.672-.438 1.062-.438s.781.156 1.062.438L11 10.751l4.594-4.594c.281-.281.672-.438 1.062-.438s.781.156 1.062.438l2.125 2.125c.281.281.438.672.438 1.062s-.156.781-.438 1.062L15.249 15l4.594 4.594c.281.281.438.672.438 1.062z"/></svg>
+    </button>
+</div>
+      </div>
+
+
   <menu type="context" id="edit-history-menu">
-    <menuitem data-action="/en-US/docs/Web/HTML/Attributes$edit" label="Edit page"></menuitem>
+    <menuitem data-action="/en-US/users/signin?next=/en-US/docs/Web/HTML/Attributes%24edit" label="Edit page"></menuitem>
     <menuitem data-action="/en-US/docs/Web/HTML/Attributes$history" label="View page history"></menuitem>
   </menu>
 
-  </div></main>
-
-  <!-- Footer -->
-  <footer><div class="center">
-    <div class="column-container">
-      <div class="column-main">
-
-        <div class="contentinfo">
-          <p>&copy; 2005-2016 Mozilla Developer Network and individual contributors.</p> <p>Content is available under <a href="/en-US/docs/MDN/About#Copyrights_and_licenses">these licenses</a>.</p>
-          <ul>
-            <li><a href="/docs/MDN/About">About MDN</a></li>
-            <li><a href="//www.mozilla.org/about/legal/terms/mozilla">Terms</a></li>
-            <li><a href="//www.mozilla.org/privacy/websites/">Privacy</a></li>
-            <li><a href="//www.mozilla.org/privacy/websites/#cookies">Cookies</a></li>
-            <li><a href="//github.com/mozilla/kuma">Contribute to the code</a></li>
-          </ul>
-        </p>
-
-        </div>
       </div>
-      <div class="column-strip">
+  </main>
+  <!-- Footer -->
+    <footer id="nav-footer" class="nav-footer">
+      <div class="center">
+          <a href="/en-US/" class="nav-footer-logo">MDN Web Docs</a>
+<div class="footer-group footer-group-mdn">
+  <h2 class="footer-title">MDN</h2>
+  <ul class="footer-list">
+    <li><a href="/en-US/docs/Web">Web Technologies</a></li>
+    <li><a href="/en-US/docs/Learn">Learn Web Development</a></li>
+    <li><a href="/docs/MDN/About">About MDN</a></li>
+    <li><a href="/en-US/docs/MDN/Feedback">Feedback</a></li>
+    <li class="footer-social">
+        <a href="https://twitter.com/mozdevnet">
+            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-twitter" width="26" height="28" viewBox="0 0 26 28" aria-label="Twitter" role="img" focusable="false">
+    <title>Twitter</title>
+    <path d="M25.312 6.375a10.85 10.85 0 0 1-2.531 2.609c.016.219.016.438.016.656 0 6.672-5.078 14.359-14.359 14.359-2.859 0-5.516-.828-7.75-2.266.406.047.797.063 1.219.063 2.359 0 4.531-.797 6.266-2.156a5.056 5.056 0 0 1-4.719-3.5c.313.047.625.078.953.078.453 0 .906-.063 1.328-.172a5.048 5.048 0 0 1-4.047-4.953v-.063a5.093 5.093 0 0 0 2.281.641 5.044 5.044 0 0 1-2.25-4.203c0-.938.25-1.797.688-2.547a14.344 14.344 0 0 0 10.406 5.281 5.708 5.708 0 0 1-.125-1.156 5.045 5.045 0 0 1 5.047-5.047 5.03 5.03 0 0 1 3.687 1.594 9.943 9.943 0 0 0 3.203-1.219 5.032 5.032 0 0 1-2.219 2.781c1.016-.109 2-.391 2.906-.781z"></path>
+</svg>
+        </a>
+    </li>
+    <li class="footer-social">
+        <a href="https://github.com/mdn/">
+            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-github" width="24" height="28" viewBox="0 0 24 28" aria-label="GitHub" role="img" focusable="false">
+    <title>GitHub</title>
+    <path d="M12 2c6.625 0 12 5.375 12 12 0 5.297-3.437 9.797-8.203 11.391-.609.109-.828-.266-.828-.578 0-.391.016-1.687.016-3.297 0-1.125-.375-1.844-.812-2.219 2.672-.297 5.484-1.313 5.484-5.922 0-1.313-.469-2.375-1.234-3.219.125-.313.531-1.531-.125-3.187-1-.313-3.297 1.234-3.297 1.234a11.28 11.28 0 0 0-6 0S6.704 6.656 5.704 6.969c-.656 1.656-.25 2.875-.125 3.187-.766.844-1.234 1.906-1.234 3.219 0 4.594 2.797 5.625 5.469 5.922-.344.313-.656.844-.766 1.609-.688.313-2.438.844-3.484-1-.656-1.141-1.844-1.234-1.844-1.234-1.172-.016-.078.734-.078.734.781.359 1.328 1.75 1.328 1.75.703 2.141 4.047 1.422 4.047 1.422 0 1 .016 1.937.016 2.234 0 .313-.219.688-.828.578C3.439 23.796.002 19.296.002 13.999c0-6.625 5.375-12 12-12zM4.547 19.234c.031-.063-.016-.141-.109-.187-.094-.031-.172-.016-.203.031-.031.063.016.141.109.187.078.047.172.031.203-.031zm.484.532c.063-.047.047-.156-.031-.25-.078-.078-.187-.109-.25-.047-.063.047-.047.156.031.25.078.078.187.109.25.047zm.469.703c.078-.063.078-.187 0-.297-.063-.109-.187-.156-.266-.094-.078.047-.078.172 0 .281s.203.156.266.109zm.656.656c.063-.063.031-.203-.063-.297-.109-.109-.25-.125-.313-.047-.078.063-.047.203.063.297.109.109.25.125.313.047zm.891.391c.031-.094-.063-.203-.203-.25-.125-.031-.266.016-.297.109s.063.203.203.234c.125.047.266 0 .297-.094zm.984.078c0-.109-.125-.187-.266-.172-.141 0-.25.078-.25.172 0 .109.109.187.266.172.141 0 .25-.078.25-.172zm.906-.156c-.016-.094-.141-.156-.281-.141-.141.031-.234.125-.219.234.016.094.141.156.281.125s.234-.125.219-.219z"></path>
+</svg>
+        </a>
+    </li>
+  </ul>
+</div>
+
+          <a href="https://mozilla.org" class="nav-footer-mozilla">Mozilla</a>
+<div class="footer-group footer-group-mozilla">
+  <h2 class="footer-title">Mozilla</h2>
+  <ul class="footer-list">
+    <li><a href="https://www.mozilla.org/about/">About</a></li>
+    <li><a href="https://www.mozilla.org/contact/">Contact Us</a></li>
+    <li><a href="https://www.mozilla.org/firefox/?utm_source=developer.mozilla.org&utm_campaign=footer&utm_medium=referral">Firefox</a></li>
+    <li class="footer-social">
+        <a href="https://twitter.com/mozilla">
+            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-twitter" width="26" height="28" viewBox="0 0 26 28" aria-label="Twitter" role="img" focusable="false">
+    <title>Twitter</title>
+    <path d="M25.312 6.375a10.85 10.85 0 0 1-2.531 2.609c.016.219.016.438.016.656 0 6.672-5.078 14.359-14.359 14.359-2.859 0-5.516-.828-7.75-2.266.406.047.797.063 1.219.063 2.359 0 4.531-.797 6.266-2.156a5.056 5.056 0 0 1-4.719-3.5c.313.047.625.078.953.078.453 0 .906-.063 1.328-.172a5.048 5.048 0 0 1-4.047-4.953v-.063a5.093 5.093 0 0 0 2.281.641 5.044 5.044 0 0 1-2.25-4.203c0-.938.25-1.797.688-2.547a14.344 14.344 0 0 0 10.406 5.281 5.708 5.708 0 0 1-.125-1.156 5.045 5.045 0 0 1 5.047-5.047 5.03 5.03 0 0 1 3.687 1.594 9.943 9.943 0 0 0 3.203-1.219 5.032 5.032 0 0 1-2.219 2.781c1.016-.109 2-.391 2.906-.781z"></path>
+</svg>
+        </a>
+    </li>
+    <li class="footer-social">
+        <a href="https://www.instagram.com/mozillagram/">
+            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-instagram" width="24" height="28" viewBox="0 0 24 28" aria-label="Instagram" role="img" focusable="false">
+    <title>Instagram</title>
+    <path d="M16 14c0-2.203-1.797-4-4-4s-4 1.797-4 4 1.797 4 4 4 4-1.797 4-4zm2.156 0c0 3.406-2.75 6.156-6.156 6.156S5.844 17.406 5.844 14 8.594 7.844 12 7.844s6.156 2.75 6.156 6.156zm1.688-6.406c0 .797-.641 1.437-1.437 1.437S16.97 8.39 16.97 7.594s.641-1.437 1.437-1.437 1.437.641 1.437 1.437zM12 4.156c-1.75 0-5.5-.141-7.078.484-.547.219-.953.484-1.375.906s-.688.828-.906 1.375c-.625 1.578-.484 5.328-.484 7.078s-.141 5.5.484 7.078c.219.547.484.953.906 1.375s.828.688 1.375.906c1.578.625 5.328.484 7.078.484s5.5.141 7.078-.484c.547-.219.953-.484 1.375-.906s.688-.828.906-1.375c.625-1.578.484-5.328.484-7.078s.141-5.5-.484-7.078c-.219-.547-.484-.953-.906-1.375s-.828-.688-1.375-.906C17.5 4.015 13.75 4.156 12 4.156zM24 14c0 1.656.016 3.297-.078 4.953-.094 1.922-.531 3.625-1.937 5.031s-3.109 1.844-5.031 1.937c-1.656.094-3.297.078-4.953.078s-3.297.016-4.953-.078c-1.922-.094-3.625-.531-5.031-1.937S.173 20.875.08 18.953C-.014 17.297.002 15.656.002 14s-.016-3.297.078-4.953c.094-1.922.531-3.625 1.937-5.031s3.109-1.844 5.031-1.937c1.656-.094 3.297-.078 4.953-.078s3.297-.016 4.953.078c1.922.094 3.625.531 5.031 1.937s1.844 3.109 1.937 5.031C24.016 10.703 24 12.344 24 14z"></path>
+</svg>
+        </a>
+    </li>
+  </ul>
+</div>
 
 
 
     <form class="languages go" method="get" action="/en-US/docs/Web">
       <label for="language">Other languages:</label>
       <select id="language" class="wiki-l10n" name="next" dir="ltr">
-        <option value="/en-US/docs/Web/HTML/Attributes" selected>
-          English (US)
+        <option title="English (US)" data-locale="en-US" value="/en-US/docs/Web/HTML/Attributes" selected>
+          English (US) (en-US)
         </option>
 
-          <option value="/bn-BD/docs/Web/HTML/Attributes">
-            বাংলা (বাংলাদেশ)
+          <option title="Bengali (Bangladesh)" data-locale="en-US" value="/bn-BD/docs/Web/HTML/Attributes">
+            বাংলা (বাংলাদেশ) (bn-BD)
           </option>
-          <option value="/es/docs/Web/HTML/Atributos">
-            Español
+          <option title="German" data-locale="en-US" value="/de/docs/Web/HTML/Attributes">
+            Deutsch (de)
           </option>
-          <option value="/fa/docs/HTML/Attributes">
-            فارسی
+          <option title="Spanish" data-locale="en-US" value="/es/docs/Web/HTML/Atributos">
+            Español (es)
           </option>
-          <option value="/fr/docs/Web/HTML/Attributes">
-            Français
+          <option title="Persian" data-locale="en-US" value="/fa/docs/HTML/Attributes">
+            فارسی (fa)
           </option>
-          <option value="/it/docs/Web/HTML/Attributi">
-            Italiano
+          <option title="French" data-locale="en-US" value="/fr/docs/Web/HTML/Attributs">
+            Français (fr)
           </option>
-          <option value="/ja/docs/Web/HTML/Attributes">
-            日本語
+          <option title="Italian" data-locale="en-US" value="/it/docs/Web/HTML/Attributi">
+            Italiano (it)
           </option>
-          <option value="/ko/docs/Web/HTML/Attributes">
-            한국어
+          <option title="Japanese" data-locale="en-US" value="/ja/docs/Web/HTML/Attributes">
+            日本語 (ja)
           </option>
-          <option value="/ms/docs/HTML/Sifat-sifat">
-            Melayu
+          <option title="Korean" data-locale="en-US" value="/ko/docs/Web/HTML/Attributes">
+            한국어 (ko)
           </option>
-          <option value="/pt-BR/docs/HTML/Attributes">
-            Português (do Brasil)
+          <option title="Malay" data-locale="en-US" value="/ms/docs/HTML/Sifat-sifat">
+            Melayu (ms)
           </option>
-          <option value="/ro/docs/Web/HTML/Atribute">
-            Română
+          <option title="Portuguese (Brazilian)" data-locale="en-US" value="/pt-BR/docs/HTML/Attributes">
+            Português (do Brasil) (pt-BR)
           </option>
-          <option value="/ru/docs/Web/HTML/Attributes">
-            Русский
+          <option title="Portuguese (Portugal)" data-locale="en-US" value="/pt-PT/docs/Web/HTML/Atributos">
+            Português (Europeu) (pt-PT)
           </option>
-          <option value="/zh-CN/docs/Web/HTML/Attributes">
-            中文 (简体)
+          <option title="Romanian" data-locale="en-US" value="/ro/docs/Web/HTML/Atribute">
+            Română (ro)
           </option>
-          <option value="/zh-TW/docs/Web/HTML/Attributes">
-            正體中文 (繁體)
+          <option title="Russian" data-locale="en-US" value="/ru/docs/Web/HTML/Attributes">
+            Русский (ru)
+          </option>
+          <option title="Ukrainian" data-locale="en-US" value="/uk/docs/Web/HTML/Attributes">
+            Українська (uk)
+          </option>
+          <option title="Chinese (Simplified)" data-locale="en-US" value="/zh-CN/docs/Web/HTML/Attributes">
+            中文 (简体) (zh-CN)
+          </option>
+          <option title="Chinese (Traditional)" data-locale="en-US" value="/zh-TW/docs/Web/HTML/Attributes">
+            正體中文 (繁體) (zh-TW)
           </option>
       </select>
       <noscript><button type="submit">Go</button></noscript>
@@ -1474,40 +1737,44 @@
 
 
 
+
+            <ul class="footer-tos">
+              <li><a href="https://www.mozilla.org/about/legal/terms/mozilla">Terms</a></li>
+              <li><a href="https://www.mozilla.org/privacy/websites/">Privacy</a></li>
+              <li><a href="https://www.mozilla.org/privacy/websites/#cookies">Cookies</a></li>
+            </ul>
+
+            <div id="license" class="contentinfo">
+              <p>&copy; 2005-2019 Mozilla and individual contributors.</p> <p>Content is available under <a href="/en-US/docs/MDN/About#Copyrights_and_licenses">these licenses</a>.</p>
+            </div>
+
       </div>
-    </div>
-  </div></footer>
+    </footer>
 
   <!-- site js -->
 
 
-    <!--[if lte IE 8]><script type="text/javascript" src="https://developer.cdn.mozilla.net/static/build/js/selectivizr.091e18cf669b.js" charset="utf-8"></script><![endif]-->
-
-    <form id="_persona_login" method="post" action="/users/persona/signin" data-csrf-token-url="/users/persona/csrf" data-request='{"siteName": "Mozilla Developer Network", "siteLogo": "/static/img/opengraph-logo.png"}' data-persona-script="https://login.persona.org/include.js">
-  <input type="hidden" name="csrfmiddlewaretoken" value="" id="_persona_csrf_token" />
-  <input type="hidden" name="next" value="" id="_persona_next_url"/>
-  <input type="hidden" name="process" value="" id="_persona_process"/>
-  <input type="hidden" name="assertion" id="_persona_assertion"/>
-</form>
+    <!--[if lte IE 8]><script type="text/javascript" src="https://developer.mozilla.org/static/build/js/selectivizr.8bb9e662e963.js" charset="utf-8"></script><![endif]-->
 
 
-    <script type="text/javascript" src="https://developer.cdn.mozilla.net/static/build/js/main.a7b27a25fb9c.js" charset="utf-8"></script>
+    <script src="https://developer.mozilla.org/static/jsi18n/en-US/javascript.414b87adc480.js"></script>
+    <script type="text/javascript" src="https://developer.mozilla.org/static/build/js/main.07c77248863e.js" charset="utf-8"></script>
+    <script>
+    if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
+  </script>
 
-      <script>
-        if(window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
-      </script>
 
-
-    <script type="text/javascript" src="https://developer.cdn.mozilla.net/static/jsi18n/en-us/javascript.b28203373cc1.js"></script>
-
-    <script async type="text/javascript" src="https://developer.cdn.mozilla.net/static/build/js/wiki.28ae780f6173.js" charset="utf-8"></script>
+    <script async type="text/javascript" src="https://developer.mozilla.org/static/build/js/wiki.4d514cee0a79.js" charset="utf-8"></script>
 
 
 
 
-  <script async type="text/javascript" src="https://developer.cdn.mozilla.net/static/build/js/helpfulness.320352cf4b63.js" charset="utf-8"></script>
 
 
+
+
+
+    <script async type="text/javascript" src="https://developer.mozilla.org/static/build/js/newsletter.a85c5c2892e5.js" charset="utf-8"></script>
 
 
 </body>

--- a/scripts/data/attributes.json
+++ b/scripts/data/attributes.json
@@ -44,6 +44,7 @@
             "elements": [
                 "form",
                 "input",
+                "select",
                 "textarea"
             ],
             "description": "Indicates whether controls in this form can by default have their values automatically completed by the browser."
@@ -243,11 +244,33 @@
             ],
             "description": "Indicates the action of the element, overriding the action defined in the <form>."
         },
+        "formEncType": {
+            "elements": [
+                "button",
+                "input"
+            ],
+            "description": "If the button/input is a submit button (type=\"submit\"), this attribute sets the encoding type to use during form submission. If this attribute is specified, it overrides the enctype attribute of the button's form owner."
+        },
+        "formMethod": {
+            "elements": [
+                "button",
+                "input"
+            ],
+            "description": "If the button/input is a submit button (type=\"submit\"), this attribute sets the submission method to use during form submission (GET, POST, etc.). If this attribute is specified, it overrides the method attribute of the button's form owner."
+        },
         "formNoValidate": {
             "elements": [
-                "button"
+                "button",
+                "input"
             ],
-            "description": "If the button is a submit button (type=\"submit\"), this Boolean attribute specifies that the form is not to be validated when it is submitted. If this attribute is specified, it overrides the novalidate attribute of the button's form owner."
+            "description": "If the button/input is a submit button (type=\"submit\"), this boolean attribute specifies that the form is not to be validated when it is submitted. If this attribute is specified, it overrides the novalidate attribute of the button's form owner."
+        },
+        "formTarget": {
+            "elements": [
+                "button",
+                "input"
+            ],
+            "description": "If the button/input is a submit button (type=\"submit\"), this attribute specifies the browsing context (for example, tab, window, or inline frame) in which to display the response that is received after submitting the form. If this attribute is specified, it overrides the target attribute of the button's form owner."
         },
         "headers": {
             "elements": [
@@ -761,6 +784,10 @@
             "disabled",
             "form",
             "formAction",
+            "formEncType",
+            "formMethod",
+            "formNoValidate",
+            "formTarget",
             "height",
             "list",
             "max",
@@ -829,6 +856,16 @@
             "src",
             "type"
         ],
+        "select": [
+            "autoComplete",
+            "autoFocus",
+            "disabled",
+            "form",
+            "multiple",
+            "name",
+            "required",
+            "size"
+        ],
         "textarea": [
             "autoComplete",
             "autoFocus",
@@ -850,7 +887,10 @@
             "disabled",
             "form",
             "formAction",
+            "formEncType",
+            "formMethod",
             "formNoValidate",
+            "formTarget",
             "name",
             "type",
             "value"
@@ -862,15 +902,6 @@
             "form",
             "keyType",
             "name"
-        ],
-        "select": [
-            "autoFocus",
-            "disabled",
-            "form",
-            "multiple",
-            "name",
-            "required",
-            "size"
         ],
         "audio": [
             "autoPlay",

--- a/scripts/extract-attributes.js
+++ b/scripts/extract-attributes.js
@@ -7,6 +7,7 @@ const str = require('string');
 
 const htmlURL = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes';
 const dataPath = './data/attributes.json';
+const htmlPath = './data/attributes.html';
 
 // From https://facebook.github.io/react/docs/tags-and-attributes.html#supported-attributes
 // less the `data` attribute,
@@ -124,6 +125,10 @@ request(htmlURL, (error, response, html) => {
     if (error) {
         throw error;
     }
+    const html2 = html.split(/\n\r|\r\n|\r|\n/).map(l => l.trimRight()).join('\n');
+    // write back to the saved copy of MDN attributes so we can see the diff
+    fs.writeFileSync(htmlPath, html2);
+
     const $ = cheerio.load(html);
     const attributes = extractAttributes($);
     const elements = extractElements(attributes);

--- a/src/components/Button.react.js
+++ b/src/components/Button.react.js
@@ -103,12 +103,27 @@ Button.propTypes = {
     'formAction': PropTypes.string,
 
     /**
-     * If the button is a submit button (type="submit"), this Boolean attribute specifies that the form is not to be validated when it is submitted. If this attribute is specified, it overrides the novalidate attribute of the button's form owner.
+     * If the button/input is a submit button (type="submit"), this attribute sets the encoding type to use during form submission. If this attribute is specified, it overrides the enctype attribute of the button's form owner.
+     */
+    'formEncType': PropTypes.string,
+
+    /**
+     * If the button/input is a submit button (type="submit"), this attribute sets the submission method to use during form submission (GET, POST, etc.). If this attribute is specified, it overrides the method attribute of the button's form owner.
+     */
+    'formMethod': PropTypes.string,
+
+    /**
+     * If the button/input is a submit button (type="submit"), this boolean attribute specifies that the form is not to be validated when it is submitted. If this attribute is specified, it overrides the novalidate attribute of the button's form owner.
      */
     'formNoValidate': PropTypes.oneOfType([
         PropTypes.oneOf(['formNoValidate', 'formnovalidate', 'FORMNOVALIDATE']),
         PropTypes.bool
      ]),
+
+    /**
+     * If the button/input is a submit button (type="submit"), this attribute specifies the browsing context (for example, tab, window, or inline frame) in which to display the response that is received after submitting the form. If this attribute is specified, it overrides the target attribute of the button's form owner.
+     */
+    'formTarget': PropTypes.string,
 
     /**
      * Name of the element. For example used by the server to identify the fields in form submits.

--- a/src/components/Select.react.js
+++ b/src/components/Select.react.js
@@ -77,6 +77,11 @@ Select.propTypes = {
     'aria-*': PropTypes.string,
 
     /**
+     * Indicates whether controls in this form can by default have their values automatically completed by the browser.
+     */
+    'autoComplete': PropTypes.string,
+
+    /**
      * The element should be automatically focused after the page loaded.
      */
     'autoFocus': PropTypes.oneOfType([


### PR DESCRIPTION
supersedes #118 - without build artifacts, thx @Marc-Andre-Rivet 

Noticed a couple of additions when I reran `generate-components` just now: for `Button`, `formEncType`, `formMethod`, `formTarget`; for `Select`: `autoComplete`. They seem reasonable...

While I was at it I had the script overwrite `data/attributes.html` so we can see the diff there (though it's pretty messy)