### PR TITLE
Add most examples (htmlScript through htmlXmp)

### DIFF
--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -209,6 +209,753 @@ r_examples:
             )
 
             app$run_server()
-    - name: 
-      dontrun:
-      code: 
+
+    - name: htmlScript
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                 
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlSection
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlSection(
+                  children = list(
+                    htmlH1("This is a section title"),
+                    htmlDiv("This is some text within a section")
+                  ) 
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlSelect
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlSelect(
+                  children = list(
+                    htmlOption("This is an option in htmlSelect"),
+                    htmlOption("But you might want to check out dccDropdown as well"),
+                    htmlOption("dccDropdown is part of the dashCoreComponents library") 
+                  ) 
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlShadow 
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                 
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlSlot
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                 
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlSmall
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is normal text",
+                htmlBr(),
+                htmlSmall("And this is text in an htmlSmall component")
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlSource
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                 
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlSpacer
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                 
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlSpan
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is some text",
+                htmlBr(),
+                htmlSpan(
+                  children = "And some text within an italicized span", 
+                  style = list(fontStyle = "italic")
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlStrike
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is normal text",
+                htmlStrike("Text within an htmlStrike element will be striked")
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlStrong
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is normal text",
+                htmlBr(),
+                htmlStrong("Text within an htmlStrong element will be Bold")
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlSub
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is normal text ",
+                htmlSub("And this is subscript text within an htmlSub")
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlSummary
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlDetails(
+                  children = list(
+                    htmlSummary(
+                      children = "Within a details element, the summary can act as a clickable description"
+                    ),
+                    "And the rest is hidden until the summary is clicked"
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlSup
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is normal text",
+                htmlSup("And this is superscript text within an htmlSup")
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlTable
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "You can create an Table with HtmlTable",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    htmlTr(
+                      list(
+                        htmlTh("Table Header 1"),
+                        htmlTh("Table Header 2")
+                      )
+                    ),
+                    htmlTr(
+                      list(
+                        htmlTd("row 1 under Header 1"),
+                        htmlTd("row 1 under Header 2")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlTbody
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "Within an htmlTable, you can specify the rows that go in the body of the table with htmlTbody",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    htmlThead(
+                      htmlTr(
+                        htmlTh("This is in the header of the table")
+                      )
+                    ),
+                    htmlTbody(
+                      htmlTr(
+                        htmlTd("This is in the body of the table")
+                      )
+                    ),
+                    htmlTfoot(
+                      htmlTr(
+                        htmlTd("This is in the footer of the table")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlTd
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "Within an htmlTable, individual cells can be made with htmlTd",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    htmlTr( 
+                      list(
+                        htmlTh("Header 1"),
+                        htmlTh("Header 2")
+                      )
+                    ),
+                    htmlTr( 
+                      list(
+                        htmlTd("this is a cell"),
+                        htmlTd("this is another cell")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlTemplate
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "You can create an HTML template to be populated later via js",
+                htmlBr(),
+                htmlTable(
+                  id = "myTable",
+                  htmlTr(
+                    list(
+                      htmlTh("Header 1"),
+                      htmlTh("Header 2")
+                    )
+                  )
+                ),
+                htmlTemplate(
+                  id = "myRowTemplate",
+                  htmlTr(
+                    list(
+                      htmlTd(className = "someRowValue"),
+                      htmlTd()
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlTextarea
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlTextarea(
+                  rows = 4, cols = 50,
+                  children = "A text aread allows users to input text"
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlTfoot
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                 
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlTh
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                 
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlThead
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "Within an htmlTable, you can create a header with htmlThead",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    htmlThead(
+                      htmlTr(
+                        htmlTh("This is in the header of the table")
+                      )
+                    ),
+                    htmlTbody(
+                      htmlTr(
+                        htmlTd("This is in the body of the table")
+                      )
+                    ),
+                    htmlTfoot(
+                      htmlTr(
+                        htmlTd("This is in the footer of the table")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlTime
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP(
+                  list(
+                    "It might be useful to wrap dates like ",
+                    htmlTime(dateTime = "2019-07-29", children = "July 29th"),
+                    " in an htmlTime to make your datetimes machine readable"
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlTitle
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                 
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlTr
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "Within an htmlTable, individual rows can be made with htmlTr",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    # the following row contains headers
+                    htmlTr( 
+                      list(
+                        htmlTh("Header 1"),
+                        htmlTh("Header 2")
+                      )
+                    ),
+                    # the following row contains cells
+                    htmlTr( 
+                      list(
+                        htmlTd("this is a cell"),
+                        htmlTd("this is another cell")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlTrack
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                 
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlU
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlU("Wrap your text in htmlU to have it underlined")
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlUl
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "You can make an unordered list with htmlUl",
+                htmlBr(),
+                htmlUl(
+                  children = list(
+                    htmlLi("Some item"),
+                    htmlLi("Some other item")
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlVar
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "You can use htmlVar to represent the name of a variable",
+                htmlBr(),
+                htmlVar("myVariable")
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlVideo
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlVideo(
+                  src = "https://ia800303.us.archive.org/18/items/bacteria_friend_and_foe/bacteria_friend_and_foe_512kb.mp4",
+                  controls = TRUE,
+                  title = "Bacteria: Friend and Foe"
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlWbr
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "In a long string, it might be a good idea to add an htmlWbr to specify word breaks",
+                htmlP("Thisverylongstringwithnowhitespaceswon'tlookverygood"),
+                htmlWbr(),
+                htmlP("butatleastyoucanspecifya'natural'placeforthestringtobebrokenup")
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlXmp
+      dontrun: TRUE
+      code: | 
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlXmp("xmp elements will be rendered in monospace font"),
+                htmlXmp("Note that this element is obsolete in HTML5"),
+                htmlA(
+                  "See this for more details", 
+                  href = "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/xmp"
+                )
+                )
+              )
+            )
+
+            app$run_server()
+
+

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -221,7 +221,7 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                 
+                 # TODO
                 )
               )
             )
@@ -286,7 +286,7 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                 
+                 # TODO
                 )
               )
             )
@@ -304,7 +304,7 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                 
+                # TODO 
                 )
               )
             )
@@ -342,7 +342,7 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                 
+                # TODO 
                 )
               )
             )
@@ -360,7 +360,7 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                 
+                # TODO 
                 )
               )
             )
@@ -650,7 +650,7 @@ r_examples:
               htmlDiv(list(
                 htmlTextarea(
                   rows = 4, cols = 50,
-                  children = "A text aread allows users to input text"
+                  children = "A text area allows users to input text"
                 )
                 )
               )
@@ -669,7 +669,27 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                 
+                "Within an htmlTable, you can create footer rows with htmlTfoot",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    htmlThead(
+                      htmlTr(
+                        htmlTh("This is in the header of the table")
+                      )
+                    ),
+                    htmlTbody(
+                      htmlTr(
+                        htmlTd("This is in the body of the table")
+                      )
+                    ),
+                    htmlTfoot(
+                      htmlTr(
+                        htmlTd("This is in the footer of the table")
+                      )
+                    )
+                  )
+                )
                 )
               )
             )
@@ -687,7 +707,17 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                 
+                htmlTable(
+                  list(
+                    # the following row contains headers
+                    htmlTr( 
+                      list(
+                        htmlTh("Header 1"),
+                        htmlTh("Header 2")
+                      )
+                    )
+                  )
+                )
                 )
               )
             )
@@ -767,7 +797,7 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                 
+                # TODO 
                 )
               )
             )
@@ -822,7 +852,7 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                 
+                # TODO 
                 )
               )
             )

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -209,7 +209,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlScript
       dontrun: TRUE
       code: | 
@@ -227,7 +226,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlSection
       dontrun: TRUE
       code: | 
@@ -250,7 +248,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlSelect
       dontrun: TRUE
       code: | 
@@ -274,7 +271,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlShadow 
       dontrun: TRUE
       code: | 
@@ -292,7 +288,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlSlot
       dontrun: TRUE
       code: | 
@@ -310,7 +305,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlSmall
       dontrun: TRUE
       code: | 
@@ -330,7 +324,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlSource
       dontrun: TRUE
       code: | 
@@ -342,13 +335,24 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                # TODO 
+                  "Resize your browser window to see the image source change based based on the browser width",
+                  htmlBr(),
+                  htmlPicture(
+                    list(
+                      htmlSource(
+                        media = "(min-width: 1000px)", 
+                        srcSet = "https://apod.nasa.gov/apod/image/1907/FishheadNebula_Pham_2401.jpg"
+                      ),
+                      htmlImg(
+                        src = "https://apod.nasa.gov/apod/image/1907/ngc3576_campbell_1824.jpg"
+                      )
+                    )
+                  )
                 )
               )
             )
 
             app$run_server()
-
     - name: htmlSpacer
       dontrun: TRUE
       code: | 
@@ -366,7 +370,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlSpan
       dontrun: TRUE
       code: | 
@@ -389,7 +392,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlStrike
       dontrun: TRUE
       code: | 
@@ -408,7 +410,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlStrong
       dontrun: TRUE
       code: | 
@@ -428,7 +429,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlSub
       dontrun: TRUE
       code: | 
@@ -447,7 +447,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlSummary
       dontrun: TRUE
       code: | 
@@ -472,7 +471,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlSup
       dontrun: TRUE
       code: | 
@@ -491,7 +489,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlTable
       dontrun: TRUE
       code: | 
@@ -526,7 +523,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlTbody
       dontrun: TRUE
       code: | 
@@ -564,7 +560,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlTd
       dontrun: TRUE
       code: | 
@@ -599,7 +594,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlTemplate
       dontrun: TRUE
       code: | 
@@ -636,7 +630,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlTextarea
       dontrun: TRUE
       code: | 
@@ -657,7 +650,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlTfoot
       dontrun: TRUE
       code: | 
@@ -695,7 +687,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlTh
       dontrun: TRUE
       code: | 
@@ -723,7 +714,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlThead
       dontrun: TRUE
       code: | 
@@ -761,7 +751,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlTime
       dontrun: TRUE
       code: | 
@@ -785,7 +774,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlTitle
       dontrun: TRUE
       code: | 
@@ -803,7 +791,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlTr
       dontrun: TRUE
       code: | 
@@ -840,7 +827,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlTrack
       dontrun: TRUE
       code: | 
@@ -858,7 +844,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlU
       dontrun: TRUE
       code: | 
@@ -876,7 +861,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlUl
       dontrun: TRUE
       code: | 
@@ -901,7 +885,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlVar
       dontrun: TRUE
       code: | 
@@ -921,7 +904,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlVideo
       dontrun: TRUE
       code: | 
@@ -943,7 +925,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlWbr
       dontrun: TRUE
       code: | 
@@ -964,7 +945,6 @@ r_examples:
             )
 
             app$run_server()
-
     - name: htmlXmp
       dontrun: TRUE
       code: | 
@@ -987,5 +967,4 @@ r_examples:
             )
 
             app$run_server()
-
 


### PR DESCRIPTION
This PR adds examples for `dashHtmlComponents`, alphabetically from `htmlScript` through `htmlXmp`.

The following examples are problematic:

- `htmlScript`: I did not successfully create a minimal `htmlScript` that actually works
- `htmlShadow`: This is [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/shadow), and I'm not sure how to show a meaningful example in the context of a dash app
- `htmlSlot`: I'm not sure how to show a meaningful example in the context of a dash app
- `htmlSpacer`: [non-standard and obsolete](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/spacer)
- `htmlTitle`: Because an app's title is set through `Dash$new(name = "title")`, I'm not sure how to show a meaningful example of `htmlTitle`
- `htmlTrack`: Not sure how to use this within a dash app with audio or video, and if there is a way, I'm not sure where I should source a `vtt` file from.