### PR TITLE
Another 33 examples for dashHtmlComponents

### DIFF
--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -253,6 +253,11 @@ r_examples:
     - name: htmlListing
       dontrun: TRUE
       code: |
+            # Warning: The <listing> element was intended as a way to render HTML code on a page.
+            # It was never properly supported, and is now deprecated. Using <listing> will almost
+            # certainly result in unexpected results. Instead, use <code>, or place the content in
+            # a <div> with the appropriate CSS styling.
+            
             library(dash)
             library(dashHtmlComponents)
             library(dashCoreComponents)
@@ -261,10 +266,6 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                htmlH2("Warning: The <listing> element was intended as a way to render HTML code on a page.
-                It was never properly supported, and is now deprecated. Using <listing> will almost
-                certainly result in unexpected results. Instead, use <code>, or place the content in
-                a <div> with the appropriate CSS styling."),
                 htmlListing(list(
                   htmlUl("A"),
                   htmlUl("B"),
@@ -350,6 +351,10 @@ r_examples:
     - name: htmlMarquee
       dontrun: TRUE
       code: |
+            # This feature is obsolete. It may still work in some
+            # browsers, but could stop working at any time. Try to
+            # avoid using this component.
+
             library(dash)
             library(dashHtmlComponents)
             library(dashCoreComponents)
@@ -359,6 +364,7 @@ r_examples:
             app$layout(
               htmlDiv(list(
                 htmlMarquee("Here is a sliding text that uses htmlMarquee")
+
               ))
             )
 
@@ -409,6 +415,9 @@ r_examples:
     - name: htmlMultiCol
       dontrun: TRUE
       code: |
+            # Warning: The <multicol> tag is obsolete, it might not work as intended.
+            # Try to avoid using it.
+
             library(dash)
             library(dashHtmlComponents)
             library(dashCoreComponents)
@@ -417,8 +426,6 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                htmlH2("Warning: The <multicol> tag is obsolete, it might not work as intended.
-                      Try to avoid using it."),
                 htmlP("htmlMulticol generates newspaper like text by specifying the cols argument,
                       an example can be found below:"),
                 htmlA(href = "https://docstore.mik.ua/orelly/web2/xhtml/ch14_02.htm#html4-CHP-14-FIG-4",
@@ -464,6 +471,9 @@ r_examples:
     - name: htmlNextid
       dontrun: TRUE
       code: |
+            # Warning: The <nextid> tag is obsolete, 
+            # it is vanished since HTML Version 3.2
+
             library(dash)
             library(dashHtmlComponents)
             library(dashCoreComponents)
@@ -472,7 +482,6 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                htmlH2("Warning: The <nextid> tag is obsolete, it is vanished since HTML Version 3.2"),
                 htmlA(href = "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nextid",
                       "Click here for more information about this tag")
               ))
@@ -691,6 +700,10 @@ r_examples:
     - name: htmlPlainText
       dontrun: TRUE
       code: |
+            # Warning: The <plaintext> tag is obsolete,
+            # it might not work as intended.
+            # Use the <pre> tag instead.
+            
             library(dash)
             library(dashHtmlComponents)
             library(dashCoreComponents)
@@ -699,8 +712,6 @@ r_examples:
 
             app$layout(
               htmlDiv(list(
-                htmlH2("Warning: The <plaintext> tag is obsolete, it might not work as intended.
-                      Use the <pre> tag instead."),
                 htmlPlaintext(),
                 htmlBr(),
                 htmlH4("The HTML Plaintext Element (<plaintext>) renders everything following

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -209,6 +209,737 @@ r_examples:
             )
 
             app$run_server()
-    - name: 
-      dontrun:
-      code: 
+    - name: htmlLi
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlOl(list(
+                  htmlLi("Montreal"),
+                  htmlLi("Toronto"),
+                  htmlLi("Halifax")
+                )),
+                htmlUl(list(
+                  htmlLi("Montreal"),
+                  htmlLi("Toronto"),
+                  htmlLi("Halifax")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlLink
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlLink(rel = "stylesheet", type = "text/css", href = "https://codepen.io/chriddyp/pen/bWLwgP.css")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlListing
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH2("Warning: The <listing> element was intended as a way to render HTML code on a page.
+                It was never properly supported, and is now deprecated. Using <listing> will almost
+                certainly result in unexpected results. Instead, use <code>, or place the content in
+                a <div> with the appropriate CSS styling."),
+                htmlListing(list(
+                  htmlUl("A"),
+                  htmlUl("B"),
+                  htmlUl("C")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMain
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlMain(
+                  list(htmlH1("Benjamin Franklin"),
+                       htmlP("Benjamin Franklin was an American polymath
+                             and one of the Founding Fathers of the United States.
+                             Franklin was a leading author, printer, political theorist,
+                             politician, Freemason, postmaster, scientist, inventor,
+                             humorist, civic activist, statesman, and diplomat."))
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMapEl
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlMapEl(
+                  name = "plotly",
+                  list(
+                  htmlArea(shape = "rect",
+                           coords = "0,0,240,290",
+                           href = "https://i.postimg.cc/TYp9sxV0/ronaldored.jpg",
+                           target = "_blank",
+                           alt = "HTML"),
+                  htmlArea(shape = "rect",
+                           coords = "241,0,480,290",
+                           href = "https://i.postimg.cc/htX5VxZS/ronaldogreen.jpg",
+                           target = "_blank",
+                           alt = "HTML")
+                  )
+                ),
+                htmlImg(useMap = "#plotly", src = "https://i.postimg.cc/nLqPMxMZ/Screen-Shot-2019-07-30-at-3-07-50-PM.png")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMark
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP(list(
+                  htmlMark("Plotly"),
+                  " develops online data analytics and visualization tools."
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMarquee
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlMarquee("Here is a sliding text that uses htmlMarquee")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMeta
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP("The <meta> tag provides metadata about the HTML document.
+                      Metadata will not be displayed on the page, but will be machine parsable.
+                      To view meta tag the content of this page can be inspected."),
+                htmlMeta(name = "author", content = "Dick Tracy")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMeter
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlLabel("Sample Level Meter: "),
+                htmlMeter(id = "sample-meter",
+                          min = 0,
+                          max = 100,
+                          low = 33,
+                          high = 66,
+                          optimum = 80,
+                          value = 80
+                          )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMultiCol
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH2("Warning: The <multicol> tag is obsolete, it might not work as intended.
+                      Try to avoid using it."),
+                htmlP("htmlMulticol generates newspaper like text by specifying the cols argument,
+                      an example can be found below:"),
+                htmlA(href = "https://docstore.mik.ua/orelly/web2/xhtml/ch14_02.htm#html4-CHP-14-FIG-4",
+                      "<multicol> Example"),
+                htmlMulticol(#cols = 3,
+                             list(
+                  htmlP("Neuralink Corporation is an American neurotechnology company
+                        founded by Elon Musk and others, developing implantable brain–machine
+                        interfaces (BMIs). The company's headquarters are in San Francisco;
+                        it was started in 2016 and was first publicly reported in March 2017."),
+                  htmlP("In April 2017, a blog called Wait But Why reported that the company aims
+                        to make devices to treat serious brain diseases in the short-term,
+                        with the eventual goal of human enhancement, sometimes called transhumanism.")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlNav
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlNav(
+                  list(
+                    htmlA("Plotly", href = "https://plot.ly/"),
+                    " > ",
+                    htmlA("Dash", href = "https://plot.ly/dash"),
+                    " > ",
+                    htmlA("Request Trial", href = "https://go.plot.ly/dash-enterprise-trial")
+                  )
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlNextid
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH2("Warning: The <nextid> tag is obsolete, it is vanished since HTML Version 3.2"),
+                htmlA(href = "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nextid",
+                      "Click here for more information about this tag")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlNobr
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlNobr("Lorem ipsum dolor sit amet,
+                         consectetur adipiscing elit, sed do eiusmod
+                         tempor incididunt ut labore et dolore magna aliqua.
+                         Ut enim ad minim veniam, quis nostrud exercitation
+                         ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                         Duis aute irure dolor in reprehenderit in voluptate
+                         velit esse cillum dolore eu fugiat nulla pariatur.
+                         Excepteur sint occaecat cupidatat non proident,
+                         sunt in culpa qui officia deserunt mollit anim id est laborum."
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlNoscript
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH2("Warning: A browser without support for JavaScript
+                      will show the text inside the noscript element.
+                      Since Dash uses Javascript internally,
+                      using this option might cause incompatibility issues."),
+                htmlNoscript("A browser without support for JavaScript
+                             will show the text inside the noscript element.")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlObjectEl
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlObjectEl(
+                  width = 100,
+                  height = 97
+                  #data = "https://i.postimg.cc/tJd8PSVf/Plotly-logo-01-square.png"
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlOl
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlOl(list(
+                  htmlLi("Un"),
+                  htmlLi("Deux"),
+                  htmlLi("Trois")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlOptgroup
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlLabel(
+                  htmlFor = "option-select", "Please select car brand/model: "
+                ),
+                htmlSelect(id = "option-select", list(
+                htmlOptgroup("Audi"), #label = "Audi"
+                htmlOption("TT"),
+                htmlOption("A4"),
+                htmlOptgroup("BMW"), #label = "BMW"
+                htmlOption("3 Series"),
+                htmlOption("5 Series")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlOption
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlSelect(list(
+                  htmlOption("Andariel"),
+                  htmlOption("Duriel"),
+                  htmlOption("Mephisto"),
+                  htmlOption("Diablo"),
+                  htmlOption("Baal")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlOutput
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                # TODO
+              ))
+            )
+
+            app$run_server()
+    - name: htmlP
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP("The <p> tag defines a paragraph.")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlParam
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP("The <param> element is used to specify the parameters that apply to
+                plugin-powered content embedded with an <object> element.
+                Read more: https://html.com/tags/param/#ixzz5vBNn4V00"),
+                htmlObjectEl(
+                  #data = "link-to-data-file"
+                  htmlParam(name = "controller", value = TRUE)
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlPicture
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlPicture(list(
+                  htmlSource(srcSet = "https://i.postimg.cc/zGSMfWDx/montreal-night.jpg",
+                             media = "(min-width: 800px)"),
+                  htmlImg(src = "https://i.postimg.cc/25Gxs7jf/montreal-day.jpg"),
+                  htmlP("Resize screen to see image changing...")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlPlainText
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH2("Warning: The <plaintext> tag is obsolete, it might not work as intended.
+                      Use the <pre> tag instead."),
+                htmlPlaintext(),
+                htmlBr(),
+                htmlH4("The HTML Plaintext Element (<plaintext>) renders everything following
+                      the start tag as raw text, ignoring any following HTML. There is no closing tag,
+                      since everything after it is considered raw text.")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlPre
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlPre(
+                  "
+                  Text in a <pre> element is displayed
+                  in a fixed-width font (usually Courier),
+                  and it preserves both spaces and line breaks.
+                  "
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlProgress
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP("Below is an example of htmlProgress"),
+                htmlProgress(value = 80, max = 100)
+              ))
+            )
+
+            app$run_server()
+    - name: htmlQ
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP(list(
+                "The <q> tag defines a short quotation: ",
+                htmlQ("This example text is wrapped in htmlQ")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlRb
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlRuby(
+                  htmlRb(
+                    "\U{65e5}"
+                  )
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlRp
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlRuby(list(
+                    "\U{6f22}",
+                    htmlRp("("),
+                    htmlRt("kan"),
+                    htmlRp(")")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlRt
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlRuby(list(
+                  "\U{5b57}",
+                  htmlRt("ji")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlRtc
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlRuby(list(
+                  "\U2661",
+                  htmlRtc(htmlRt(" Heart"))
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlRuby
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlRuby("\U{54d0}")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlS
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlS("htmlS  generates bold text"),
+                htmlP("htmlS  generates striked-through text")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlSamp
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlSamp("htmlSamp formats text to computer program output.")
+              ))
+            )
+
+            app$run_server()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -954,3 +954,2276 @@ r_examples:
 
 
 
+pkg_help_description: >
+    Dash is a web application framework that
+    provides pure Python and R abstraction around HTML, CSS, and
+    JavaScript. Instead of writing HTML or using an HTML
+    templating engine, you compose your layout using R
+    functions within the dashHtmlComponents package. The
+    source for this package is on GitHub:
+    plotly/dash-html-components.
+pkg_help_title: >
+    Vanilla HTML Components for Dash
+
+r_examples:
+    - name: htmlA
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlA(children="Link to external site",
+                      href="https://plot.ly",
+                      target="_blank")
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlAbbr
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+               htmlDiv(list(
+                 htmlAbbr(children="\U{1F50D} Hover over this line for a few seconds and see the text box appear...",
+                          title="Hello! htmlAbbr at work!")
+                  )
+               )
+            )
+
+            app$run_server()
+    - name: htmlAcronym
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlAcronym(children="Mouse over these words to see the acronym for \"as soon as possible\".",
+                title="ASAP")
+                  )
+              )
+            )
+
+            app$run_server()
+    - name: htmlAddress
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlAddress(children="5555 Avenue de Gasp\U{00E9}, Montréal QC H2T 2A3")
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlArea
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlImg(src = "https://upload.wikimedia.org/wikipedia/commons/0/0c/PIA17351-ApparentSizes-MarsDeimosPhobos-EarthMoon.jpg",
+                        useMap = "#image-map"),
+                htmlMapEl(list(
+                  htmlArea(target="_blank",
+                           alt="Deimos",
+                           title="Deimos",
+                           href="https://en.wikipedia.org/wiki/Deimos_(moon)",
+                           coords="5,114,32,147",
+                           shape="rect"),
+                  htmlArea(target="_blank",
+                           alt="Phobos",
+                           title="Phobos",
+                           href="https://en.wikipedia.org/wiki/Phobos_(moon)",
+                           coords="113,196,32,103",
+                           shape="rect"),
+                  htmlArea(target="_blank",
+                           alt="Moon",
+                           title="Moon",
+                           href="https://en.wikipedia.org/wiki/Moon",
+                           coords="127,285,294,1",
+                           shape="rect")
+                  ),
+                  name = "image-map"
+                ),
+                htmlDiv(children = "Click on the image to visit a Wikipedia article",
+                        id = "object-name")
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlArticle
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlArticle(list(
+                  htmlH2("Dash for R launched!"),
+                  htmlP("Dash is a user interface library for creating analytical web applications.\n
+                         Those who use R for data analysis, data exploration, visualization,\n
+                         modelling, instrument control, and reporting will find immediate use for Dash for R."),
+                  htmlAside("Plotly is a technical computing company with offices in Montr\U{00E9}al, Canada and Cambridge, Massachusetts.")
+                  )
+                )
+               )
+              )
+            )
+
+            app$run_server()
+    - name: htmlAside
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlArticle(list(
+                  htmlH2("Dash for R launched!"),
+                  htmlP("Dash is a user interface library for creating analytical web applications.\n
+                         Those who use R for data analysis, data exploration, visualization,\n
+                         modelling, instrument control, and reporting will find immediate use for Dash for R."),
+                  htmlAside("Plotly is a technical computing company with offices in Montr\U{00E9}al, Canada and Cambridge, Massachusetts.")
+                  )
+                )
+               )
+              )
+            )
+
+            app$run_server()
+    - name: htmlAudio
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlAudio(src="https://www.nasa.gov/62284main_onesmall2.wav",
+                          controls=TRUE,
+                          title="Apollo 11 - July 16, 1969 - Neil Armstrong")
+                  )
+               )
+            )
+
+            app$run_server()
+    - name: htmlB
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlB(children="This is a bold statement!"),
+                htmlP(children="This is not so bold.")
+                )
+               )
+            )
+
+            app$run_server()
+    - name: htmlDialog
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(htmlDiv(list(
+              htmlDialog(
+                children = htmlP('Greetings')
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlDiv
+      dontrun: TRUE
+      code: |
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlDiv('This Title is Wrapped inside an inner Div')
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlDl
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(htmlDiv(list(
+              htmlDl(
+                children= list('Dash',
+                htmlDd('Dash is a framework for building web
+                      applications.'))
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlDt
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(htmlDiv(list(
+              htmlDl(
+                children= list(htmlDt("Dash for R"),
+                              htmlDd('HtmlDt and htmlDD must be used
+                                      within htmlDl'))
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlElement
+      dontrun: TRUE
+      code: |
+
+            # This feature is obsolete. It may still work in some
+            # browsers, but could stop working at any time. Try to
+            # avoid using this component.
+
+    - name: htmlEm
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(htmlDiv(list(
+              htmlH1(list('Dash is a very ',
+                          htmlEm(' important '),
+                          'framework')
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlEmbed
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(htmlDiv(list(
+              htmlEmbed(
+                src = 'https://www.youtube.com/watch?v=njW7DmeK1Qk',
+                width = '250',
+                height = '500')
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlFieldset
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(htmlDiv(list(
+              htmlFieldset(
+                children = list('Choose your favourite Dash HTML component',
+                dccRadioItems(
+                  options=list(
+                    list("label" = "htmlDiv", "value" = "htmlDiv"),
+                    list("label" = "htmlBase", "value" = "htmlBase"),
+                    list("label" = "htmlArticle", "value" = "htmlArticle")
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlFigcaption
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(htmlDiv(list(
+              htmlFigure(children = list(
+                htmlImg(src = 'https://brand.plot.ly/static/images/plotly-logo-01-stripe@2x.png'),
+                htmlFigcaption(children = 'Plotly Logo')))
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlFigure
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(htmlDiv(list(
+              htmlFigure(children = list(
+                htmlImg(src = 'https://brand.plot.ly/static/images/plotly-logo-01-stripe@2x.png',
+                        width = '400',
+                        height = '150')
+                    )
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlFont
+      dontrun: TRUE
+      code: |
+
+            Starting with HTML 4, HTML does not convey styling information
+            anymore (outside the <style> element or the style attribute of each
+            element). For any new web development, styling should be written using CSS only.
+
+    - name: htmlFooter
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+
+            app$layout(htmlDiv(list(
+              htmlFooter(list(
+                htmlH1('Dash'),
+                htmlLi('Pointer1'),
+                htmlLi('Pointer2')
+                    )
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlForm
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+
+            app$layout(htmlDiv(list(
+              htmlForm(children=list(
+                htmlP(children=list("Username: ", dccInput(type='text', id='username', placeholder='username'))),
+                htmlP(children=list("Password: ", dccInput(type='password', id='password', placeholder='password'))),
+                htmlButton(children=list('Login'), type='submit', id='login_button')
+                    )
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: HtmlFrame
+      dontrun: TRUE
+      code: |
+            HtmlFrame is now depreciated. htmlIFrame is now recommended.
+
+    - name: HtmlFrameset
+      dontrun: TRUE
+      code: |
+
+            app <- Dash$new()
+
+
+            app$layout(htmlDiv(list(
+              htmlFrameset(children =
+              htmlIframe(width = "600px", height = "600px",
+                         src = "https://dashr.plot.ly/")
+                ))
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlH1
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH1(list(
+                  'Dash Html',
+                  htmlBr(), #We can customize
+                  htmlSpan('Dash', style = list('opacity' = '0.8')),
+                  htmlSpan(' Core')))
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlH2
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH2(list(
+                  'Dash Html',
+                  htmlBr(), #We can customize
+                  htmlSpan('Dash', style = list('opacity' = '0.8')),
+                  htmlSpan(' Core')))
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlH3
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH3(list(
+                  'Dash Html',
+                  htmlBr(), #We can customize
+                  htmlSpan('Dash', style = list('opacity' = '0.8')),
+                  htmlSpan(' Core')))
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlH4
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH4(list(
+                  'Dash Html',
+                  htmlBr(), #We can customize
+                  htmlSpan('Dash', style = list('opacity' = '0.8')),
+                  htmlSpan(' Core')))
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlH5
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH5(list(
+                  'Dash Html',
+                  htmlBr(), #We can customize
+                  htmlSpan('Dash', style = list('opacity' = '0.8')),
+                  htmlSpan(' Core')))
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlH6
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH6(list(
+                  'Dash Html',
+                  htmlBr(), #We can customize
+                  htmlSpan('Dash', style = list('opacity' = '0.8')),
+                  htmlSpan(' Core')))
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlHgroup
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlHgroup(list(
+                  htmlH1('MultiLevel Title'),
+                  htmlHr(),
+                  htmlH2('Header')
+                    )
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlHr
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlDiv(list(
+                  htmlH1('Dash'),
+                  htmlHr(),
+                  htmlH2('Components')
+                    )
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlI
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                  htmlI('Italicized Text')
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlIFrame
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+
+            app$layout(htmlDiv(list(
+              htmlIframe(width = "600px", height = "600px",
+                        src = "https://dashr.plot.ly/")
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlImg
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(htmlDiv(list(
+                htmlImg(src ='https://brand.plot.ly/static/images/plotly-logo-01-stripe@2x.png',
+                        height='200', width='400')
+                )
+              )
+            )
+
+
+            app$run_server()
+
+    - name: htmlIns
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlIns('This text has been inserted')
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlIsindex
+      dontrun: TRUE
+      code: |
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlIsindex(prompt = 'Search Document..')
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlKbd
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP('Please Press: '),
+                htmlKbd(list(
+                  'Ctl + ',
+                  'Alt + ',
+                  'Delete'))
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlKeygen
+      dontrun: TRUE
+      code: |
+
+            This feature is obsolete. It may still work in some
+            browsers, but could stop working at any time. Try to
+            avoid using this component.
+
+    - name: htmlLabel
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(
+                htmlLabel(
+                  list(htmlDiv(list("Time points")),
+                      dccInput(
+                        id = "times-input",
+                        placeholder = "Enter a value...",
+                        type = "number",
+                        value = 1,
+                        min = 3,
+                        max = 999)
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+
+    - name: htmlLegend
+      dontrun: TRUE
+      code: |
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(htmlDiv(list(
+              htmlFieldset(
+                children = list(
+                                htmlLegend('Select your favourite component'),
+                                dccRadioItems(
+                                  options=list(
+                                    list("label" = "htmlDiv", "value" = "htmlDiv"),
+                                    list("label" = "htmlBase", "value" = "htmlBase"),
+                                    list("label" = "htmlArticle", "value" = "htmlArticle")
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlLi
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlOl(list(
+                  htmlLi("Montreal"),
+                  htmlLi("Toronto"),
+                  htmlLi("Halifax")
+                )),
+                htmlUl(list(
+                  htmlLi("Montreal"),
+                  htmlLi("Toronto"),
+                  htmlLi("Halifax")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlLink
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlLink(rel = "stylesheet", type = "text/css", href = "https://codepen.io/chriddyp/pen/bWLwgP.css")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlListing
+      dontrun: TRUE
+      code: |
+            # Warning: The <listing> element was intended as a way to render HTML code on a page.
+            # It was never properly supported, and is now deprecated. Using <listing> will almost
+            # certainly result in unexpected results. Instead, use <code>, or place the content in
+            # a <div> with the appropriate CSS styling.
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlListing(list(
+                  htmlUl("A"),
+                  htmlUl("B"),
+                  htmlUl("C")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMain
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlMain(
+                  list(htmlH1("Benjamin Franklin"),
+                       htmlP("Benjamin Franklin was an American polymath
+                             and one of the Founding Fathers of the United States.
+                             Franklin was a leading author, printer, political theorist,
+                             politician, Freemason, postmaster, scientist, inventor,
+                             humorist, civic activist, statesman, and diplomat."))
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMapEl
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlImg(src = "https://upload.wikimedia.org/wikipedia/commons/0/0c/PIA17351-ApparentSizes-MarsDeimosPhobos-EarthMoon.jpg",
+                        useMap = "#image-map"),
+                htmlMapEl(list(
+                  htmlArea(target="_blank",
+                           alt="Deimos",
+                           title="Deimos",
+                           href="https://en.wikipedia.org/wiki/Deimos_(moon)",
+                           coords="5,114,32,147",
+                           shape="rect"),
+                  htmlArea(target="_blank",
+                           alt="Phobos",
+                           title="Phobos",
+                           href="https://en.wikipedia.org/wiki/Phobos_(moon)",
+                           coords="113,196,32,103",
+                           shape="rect"),
+                  htmlArea(target="_blank",
+                           alt="Moon",
+                           title="Moon",
+                           href="https://en.wikipedia.org/wiki/Moon",
+                           coords="127,285,294,1",
+                           shape="rect")
+                  ),
+                  name = "image-map"
+                ),
+                htmlDiv(children = "Click on the image to visit a Wikipedia article",
+                        id = "object-name")
+                )
+              )
+            )
+            app$run_server()
+    - name: htmlMark
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP(list(
+                  htmlMark("Plotly"),
+                  " develops online data analytics and visualization tools."
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMarquee
+      dontrun: TRUE
+      code: |
+            # This feature is obsolete. It may still work in some
+            # browsers, but could stop working at any time. Try to
+            # avoid using this component.
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlMarquee("Here is some sliding text that uses htmlMarquee")
+
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMeta
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP("The <meta> tag provides metadata about the HTML document.
+                      Metadata will not be displayed on the page, but will be machine parsable.
+                      To view meta tag the content of this page can be inspected."),
+                htmlMeta(name = "author", content = "Edward Tufte")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMeter
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlLabel("Sample Level Meter: "),
+                htmlMeter(id = "sample-meter",
+                          min = 0,
+                          max = 100,
+                          low = 33,
+                          high = 66,
+                          optimum = 80,
+                          value = 80
+                          )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlMultiCol
+      dontrun: TRUE
+      code: |
+            # Warning: The <multicol> tag is obsolete, it might not work as intended.
+            # Try to avoid using it.
+    - name: htmlNav
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlNav(
+                  list(
+                    htmlA("Plotly", href = "https://plot.ly/"),
+                    " > ",
+                    htmlA("Dash", href = "https://plot.ly/dash"),
+                    " > ",
+                    htmlA("Request Trial", href = "https://go.plot.ly/dash-enterprise-trial")
+                  )
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlNextid
+      dontrun: TRUE
+      code: |
+            # Warning: The <nextid> tag is obsolete,
+            # it is vanished since HTML Version 3.2
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlA(href = "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nextid",
+                      "Click here for more information about this tag")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlNobr
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlNobr("Lorem ipsum dolor sit amet,
+                         consectetur adipiscing elit, sed do eiusmod
+                         tempor incididunt ut labore et dolore magna aliqua.
+                         Ut enim ad minim veniam, quis nostrud exercitation
+                         ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                         Duis aute irure dolor in reprehenderit in voluptate
+                         velit esse cillum dolore eu fugiat nulla pariatur.
+                         Excepteur sint occaecat cupidatat non proident,
+                         sunt in culpa qui officia deserunt mollit anim id est laborum."
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlNoscript
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH2("Warning: A browser without support for JavaScript
+                      will show the text inside the noscript element.
+                      Since Dash uses Javascript internally,
+                      using this option might cause incompatibility issues."),
+                htmlNoscript("A browser without support for JavaScript
+                             will show the text inside the noscript element.")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlObjectEl
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlObjectEl(
+                  width = 100,
+                  height = 97
+                  #data = "https://i.postimg.cc/tJd8PSVf/Plotly-logo-01-square.png"
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlOl
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlOl(list(
+                  htmlLi("Un"),
+                  htmlLi("Deux"),
+                  htmlLi("Trois")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlOptgroup
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlLabel(
+                  htmlFor = "option-select", "Please select car brand/model: "
+                ),
+                htmlSelect(id = "option-select", list(
+                htmlOptgroup("Audi"), #label = "Audi"
+                htmlOption("TT"),
+                htmlOption("A4"),
+                htmlOptgroup("BMW"), #label = "BMW"
+                htmlOption("3 Series"),
+                htmlOption("5 Series")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlOption
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlSelect(list(
+                  htmlOption("d'Artagnan"),
+                  htmlOption("Athos"),
+                  htmlOption("Porthos"),
+                  htmlOption("Aramis")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlOutput
+      dontrun: TRUE
+      code:
+    - name: htmlP
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP("The <p> tag defines a paragraph.")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlParam
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP("The <param> element is used to specify the parameters that apply to
+                plugin-powered content embedded with an <object> element.
+                Read more: https://html.com/tags/param/#ixzz5vBNn4V00"),
+                htmlObjectEl(
+                  #data = "link-to-data-file"
+                  htmlParam(name = "controller", value = TRUE)
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlPicture
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlPicture(list(
+                  htmlSource(srcSet = "https://upload.wikimedia.org/wikipedia/commons/a/a7/Winter_and_the_City.jpg",
+                             media = "(min-width: 800px)"),
+                  htmlImg(src = "https://upload.wikimedia.org/wikipedia/commons/5/56/Summer_and_the_City.jpg"),
+                  htmlP("Resize screen to see image changing...")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlPlainText
+      dontrun: TRUE
+      code: |
+            # Warning: The <plaintext> tag is obsolete,
+            # it might not work as intended.
+            # Use the <pre> tag instead.
+
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlPlaintext(),
+                htmlBr(),
+                htmlH4("The HTML Plaintext Element (<plaintext>) renders everything following
+                      the start tag as raw text, ignoring any following HTML. There is no closing tag,
+                      since everything after it is considered raw text.")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlPre
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlPre(
+                  "
+                  Text in a <pre> element is displayed
+                  in a fixed-width font (usually Courier),
+                  and it preserves both spaces and line breaks.
+                  "
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlProgress
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP("Below is an example of htmlProgress"),
+                htmlProgress(value = 80, max = 100)
+              ))
+            )
+
+            app$run_server()
+    - name: htmlQ
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP(list(
+                "The <q> tag defines a short quotation: ",
+                htmlQ("This example text is wrapped in htmlQ")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlRb
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlRuby(
+                  htmlRb(
+                    "\U{65e5}"
+                  )
+                )
+              ))
+            )
+
+            app$run_server()
+    - name: htmlRp
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlRuby(list(
+                    "\U{6f22}",
+                    htmlRp("("),
+                    htmlRt("kan"),
+                    htmlRp(")")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlRt
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlRuby(list(
+                  "\U{5b57}",
+                  htmlRt("ji")
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlRtc
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlRuby(list(
+                  "\U2661",
+                  htmlRtc(htmlRt(" Heart"))
+                ))
+              ))
+            )
+
+            app$run_server()
+    - name: htmlRuby
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlRuby("\U{54d0}")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlS
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlS("htmlS  generates strikethrough text"),
+                htmlP("htmlB  generates bold text")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlSamp
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlSamp("htmlSamp formats text to computer program output.")
+              ))
+            )
+
+            app$run_server()
+    - name: htmlScript
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                 # TODO
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlSection
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlSection(
+                  children = list(
+                    htmlH1("This is a section title"),
+                    htmlDiv("This is some text within a section")
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlSelect
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlSelect(
+                  children = list(
+                    htmlOption("This is an option in htmlSelect"),
+                    htmlOption("But you might want to check out dccDropdown as well"),
+                    htmlOption("dccDropdown is part of the dashCoreComponents library")
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlShadow
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                 # TODO
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlSlot
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                # TODO
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlSmall
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is normal text",
+                htmlBr(),
+                htmlSmall("And this is text in an htmlSmall component")
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlSource
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                  "Resize your browser window to see the image source change based based on the browser width",
+                  htmlBr(),
+                  htmlPicture(
+                    list(
+                      htmlSource(
+                        media = "(min-width: 1000px)",
+                        srcSet = "https://apod.nasa.gov/apod/image/1907/FishheadNebula_Pham_2401.jpg"
+                      ),
+                      htmlImg(
+                        src = "https://apod.nasa.gov/apod/image/1907/ngc3576_campbell_1824.jpg"
+                      )
+                    )
+                  )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlSpacer
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                # TODO
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlSpan
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is some text",
+                htmlBr(),
+                htmlSpan(
+                  children = "And some text within an italicized span",
+                  style = list(fontStyle = "italic")
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlStrike
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is normal text",
+                htmlStrike("Text within an htmlStrike element will be striked")
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlStrong
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is normal text",
+                htmlBr(),
+                htmlStrong("Text within an htmlStrong element will be Bold")
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlSub
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is normal text ",
+                htmlSub("And this is subscript text within an htmlSub")
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlSummary
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlDetails(
+                  children = list(
+                    htmlSummary(
+                      children = "Within a details element, the summary can act as a clickable description"
+                    ),
+                    "And the rest is hidden until the summary is clicked"
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlSup
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "This is normal text",
+                htmlSup("And this is superscript text within an htmlSup")
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlTable
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "You can create an Table with HtmlTable",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    htmlTr(
+                      list(
+                        htmlTh("Table Header 1"),
+                        htmlTh("Table Header 2")
+                      )
+                    ),
+                    htmlTr(
+                      list(
+                        htmlTd("row 1 under Header 1"),
+                        htmlTd("row 1 under Header 2")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlTbody
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "Within an htmlTable, you can specify the rows that go in the body of the table with htmlTbody",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    htmlThead(
+                      htmlTr(
+                        htmlTh("This is in the header of the table")
+                      )
+                    ),
+                    htmlTbody(
+                      htmlTr(
+                        htmlTd("This is in the body of the table")
+                      )
+                    ),
+                    htmlTfoot(
+                      htmlTr(
+                        htmlTd("This is in the footer of the table")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlTd
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "Within an htmlTable, individual cells can be made with htmlTd",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    htmlTr(
+                      list(
+                        htmlTh("Header 1"),
+                        htmlTh("Header 2")
+                      )
+                    ),
+                    htmlTr(
+                      list(
+                        htmlTd("this is a cell"),
+                        htmlTd("this is another cell")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlTemplate
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "You can create an HTML template to be populated later via js",
+                htmlBr(),
+                htmlTable(
+                  id = "myTable",
+                  htmlTr(
+                    list(
+                      htmlTh("Header 1"),
+                      htmlTh("Header 2")
+                    )
+                  )
+                ),
+                htmlTemplate(
+                  id = "myRowTemplate",
+                  htmlTr(
+                    list(
+                      htmlTd(className = "someRowValue"),
+                      htmlTd()
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlTextarea
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlTextarea(
+                  rows = 4, cols = 50,
+                  children = "A text area allows users to input text"
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlTfoot
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "Within an htmlTable, you can create footer rows with htmlTfoot",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    htmlThead(
+                      htmlTr(
+                        htmlTh("This is in the header of the table")
+                      )
+                    ),
+                    htmlTbody(
+                      htmlTr(
+                        htmlTd("This is in the body of the table")
+                      )
+                    ),
+                    htmlTfoot(
+                      htmlTr(
+                        htmlTd("This is in the footer of the table")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlTh
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlTable(
+                  list(
+                    # the following row contains headers
+                    htmlTr(
+                      list(
+                        htmlTh("Header 1"),
+                        htmlTh("Header 2")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlThead
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "Within an htmlTable, you can create a header with htmlThead",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    htmlThead(
+                      htmlTr(
+                        htmlTh("This is in the header of the table")
+                      )
+                    ),
+                    htmlTbody(
+                      htmlTr(
+                        htmlTd("This is in the body of the table")
+                      )
+                    ),
+                    htmlTfoot(
+                      htmlTr(
+                        htmlTd("This is in the footer of the table")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlTime
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlP(
+                  list(
+                    "It might be useful to wrap dates like ",
+                    htmlTime(dateTime = "2019-07-29", children = "July 29th"),
+                    " in an htmlTime to make your datetimes machine readable"
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlTitle
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                # TODO
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlTr
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "Within an htmlTable, individual rows can be made with htmlTr",
+                htmlBr(),
+                htmlTable(
+                  list(
+                    # the following row contains headers
+                    htmlTr(
+                      list(
+                        htmlTh("Header 1"),
+                        htmlTh("Header 2")
+                      )
+                    ),
+                    # the following row contains cells
+                    htmlTr(
+                      list(
+                        htmlTd("this is a cell"),
+                        htmlTd("this is another cell")
+                      )
+                    )
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlTrack
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                # TODO
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlU
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlU("Wrap your text in htmlU to have it underlined")
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlUl
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "You can make an unordered list with htmlUl",
+                htmlBr(),
+                htmlUl(
+                  children = list(
+                    htmlLi("Some item"),
+                    htmlLi("Some other item")
+                  )
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlVar
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "You can use htmlVar to represent the name of a variable",
+                htmlBr(),
+                htmlVar("myVariable")
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlVideo
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlVideo(
+                  src = "https://ia800303.us.archive.org/18/items/bacteria_friend_and_foe/bacteria_friend_and_foe_512kb.mp4",
+                  controls = TRUE,
+                  title = "Bacteria: Friend and Foe"
+                )
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlWbr
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                "In a long string, it might be a good idea to add an htmlWbr to specify word breaks",
+                htmlP("Thisverylongstringwithnowhitespaceswon'tlookverygood"),
+                htmlWbr(),
+                htmlP("butatleastyoucanspecifya'natural'placeforthestringtobebrokenup")
+                )
+              )
+            )
+
+            app$run_server()
+    - name: htmlXmp
+      dontrun: TRUE
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlXmp("xmp elements will be rendered in monospace font"),
+                htmlXmp("Note that this element is obsolete in HTML5"),
+                htmlA(
+                  "See this for more details",
+                  href = "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/xmp"
+                )
+                )
+              )
+            )
+
+            app$run_server()


### PR DESCRIPTION
Adding below 33 examples:
 ```
[1] "htmlLi"        "htmlLink"      "htmlListing"   "htmlMain"      "htmlMapEl"     "htmlMark"     
[7] "htmlMarquee"   "htmlMeta"      "htmlMeter"     "htmlMulticol"  "htmlNav"       "htmlNextid"   
[13] "htmlNobr"      "htmlNoscript"  "htmlObjectEl"  "htmlOl"        "htmlOptgroup"  "htmlOption"   
[19] "htmlOutput"    "htmlP"         "htmlParam"     "htmlPicture"   "htmlPlaintext" "htmlPre"      
[25] "htmlProgress"  "htmlQ"         "htmlRb"        "htmlRp"        "htmlRt"        "htmlRtc"      
[31] "htmlRuby"      "htmlS"         "htmlSamp"   
```
Examples with various problems and their current status are:

- `htmlLink`: Since `externalSheets` are added via `Dash$new(external_stylesheets = externalSheets)` to the `<head>` section, not sure how to include a meaningful example 

- `htmlListing`: Deprecated. Example working 

- `htmlMarquee`: Obsolete. Example working 

- `htmlMeta`: Example added but injects `<meta>` tag to `<body>`. Not sure if this is acceptable

- `htmlMultiCol`: Obsolete. Example added (requires `col` arg and netscape 4 to work)

- `htmlNextid`: Needs to be injected in the `<head>` and not supported by any browser. Could not add an example

- `htmlObjectEl`: Example created but not working. `object` tag  has `data` attribute but `htmlObjectEl` does not. There is an [issue](https://github.com/plotly/dash-html-components/issues/66) created earlier

- `htmlOptgroup`: Example working. However, labels are blank. Noted that `optgroup` should have `label` argument. Below is how it looks vs. how it is supposed to look:
<img width="224" alt="Screen Shot 2019-07-30 at 5 11 45 PM" src="https://user-images.githubusercontent.com/20918264/62165811-42401500-b2ed-11e9-8f17-a567438abe2e.png">                                                  <img width="120" alt="Screen Shot 2019-07-30 at 5 12 15 PM" src="https://user-images.githubusercontent.com/20918264/62165821-48ce8c80-b2ed-11e9-960f-726486234238.png">

- `htmlOutput`: Need `oninput` attribute of `htmlForm` & `htmlInput`(does not exist) to create a working example

- `htmlParam`: Example added but not working. Depends on `data` attribute of  `htmlObjectEl`

- `htmlPlaintext`: Obsolote. Example added but does not work as intended (should render rest of html as plain-text)