### PR TITLE
Fix LICENSE for dashHtmlComponents install on Windows

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -29,6 +29,6 @@ MANIFEST.in
 CHANGELOG.md
 test/
 # CRAN has weird LICENSE requirements
-LICENSE.txt
+LICENSE.md
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,2 @@
-LICENSE.txt
+YEAR: 2020
+COPYRIGHT HOLDER: Plotly, Inc.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Plotly
+Copyright (c) 2020 Plotly
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,6 @@ include dash_html_components/dash_html_components.min.js
 include dash_html_components/dash_html_components.min.js.map
 include dash_html_components/metadata.json
 include dash_html_components/package-info.json
-include LICENSE
+include LICENSE.md
 include README.md
 include package.json


### PR DESCRIPTION
While trying to install `dashHtmlComponents` on a Windows instance, the following error was encountered:

![image](https://user-images.githubusercontent.com/9809798/74559789-2a4f7c00-4f33-11ea-9332-7a678902d70c.png)

This PR proposes to
- remove the symlink `LICENSE` which points to `LICENSE.txt` so that the R package will install properly
- add a `LICENSE.md` file which will properly render the MIT license within GitHub
- add a `LICENSE` file which contains the text required by CRAN when submitting packages (see https://cran.r-project.org/web/licenses/MIT)
- add `LICENSE.md` to `.Rbuildignore` to ensure package installs properly
- update `MANIFEST.in` to include `LICENSE.md`

If this arrangement is suitable for `dash-html-components`, it may be used for other repos in the future.