### PR TITLE
Update R package artifacts for CRAN submission

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
               . venv/bin/activate
               pip install -e ./dash-main[testing,dev] --quiet
               cd dash-core-components && npm ci && npm run build && pip install -e . && cd ..
-              cd dash-main/dash-renderer && npm run build && pip install -e . && cd ../..
+              cd dash-main/dash-renderer && npm ci && npm run build && pip install -e . && cd ../..
               cd dash-table && npm ci && npm run build && pip install -e . && cd ..
 
       - run:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 1.0.3
 Description: 'Dash' is a web application framework that provides pure Python and R abstraction around HTML, CSS, and JavaScript. Instead of writing HTML or using an HTML templating engine, you compose your layout using R functions within the 'dashHtmlComponents' package. The source for this package is on GitHub: plotly/dash-html-components.
 Depends: R (>= 3.0.2)
 Imports: 
-Suggests: knitr, rmarkdown
+Suggests: dash, dashCoreComponents, knitr, rmarkdown
 Authors@R: c(person("Chris", "Parmer", email = "chris@plotly.com", role = c("aut")), person("Ryan Patrick", "Kyle", email = "ryan@plotly.com", role = c("cre"), comment = c(ORCID = "0000-0002-4958-2844")), person(family = "Plotly Technologies, Inc.", role = "cph"))
 License: MIT + file LICENSE
 Copyright: Plotly Technologies, Inc.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,16 +1,16 @@
 Package: dashHtmlComponents
-Title: Vanilla HTML Components for Dash
+Title: Vanilla HTML Components for 'Dash'
 Version: 1.0.3
-Description: Dash is a web application framework that provides pure Python and R abstraction around HTML, CSS, and JavaScript. Instead of writing HTML or using an HTML templating engine, you compose your layout using R functions within the dashHtmlComponents package. The source for this package is on GitHub: plotly/dash-html-components.
+Description: 'Dash' is a web application framework that provides pure Python and R abstraction around HTML, CSS, and JavaScript. Instead of writing HTML or using an HTML templating engine, you compose your layout using R functions within the 'dashHtmlComponents' package. The source for this package is on GitHub: plotly/dash-html-components.
 Depends: R (>= 3.0.2)
 Imports: 
 Suggests: knitr, rmarkdown
+Authors@R: c(person("Chris", "Parmer", email = "chris@plotly.com", role = c("aut")), person("Ryan Patrick", "Kyle", email = "ryan@plotly.com", role = c("cre"), comment = c(ORCID = "0000-0002-4958-2844")), person(family = "Plotly Technologies, Inc.", role = "cph"))
 License: MIT + file LICENSE
+Copyright: Plotly Technologies, Inc.
 URL: https://github.com/plotly/dash-html-components
 BugReports: https://github.com/plotly/dash-html-components/issues
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr
 KeepSource: true
-Author: Chris Parmer [aut]
-Maintainer: Ryan Patrick Kyle <ryan@plotly.com>

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -1,1945 +1,2159 @@
 pkg_help_description: >-
-    Dash is a web application framework that
+    'Dash' is a web application framework that
     provides pure Python and R abstraction around HTML, CSS, and
     JavaScript. Instead of writing HTML or using an HTML
     templating engine, you compose your layout using R
-    functions within the dashHtmlComponents package. The
+    functions within the 'dashHtmlComponents' package. The
     source for this package is on GitHub:
     plotly/dash-html-components.
 pkg_help_title: >-
-    Vanilla HTML Components for Dash
+    Vanilla HTML Components for 'Dash'
+pkg_authors: >-
+    c(person("Chris", "Parmer", email = "chris@plotly.com", role = c("aut")), person("Ryan Patrick", "Kyle", email = "ryan@plotly.com", role = c("cre"), comment = c(ORCID = "0000-0002-4958-2844")), person(family = "Plotly Technologies, Inc.", role = "cph"))
+pkg_copyright: >-
+    Plotly Technologies, Inc.
 r_examples:
     - name: htmlA
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlA(children='Link to external site',
-                      href='https://plotly.com',
-                      target='_blank')
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlAbbr
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-               htmlDiv(list(
-                 htmlAbbr(children='Hello! htmlAbbr at work!',
-                          title='\U{1F50D} Hover over this line for a few seconds and see the text box appear...')
-                  )
-               )
-            )
-
-            app$run_server()
-    - name: htmlAcronym
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlAcronym(children='ASAP',
-                title='Mouse over these words to see the acronym for \'as soon as possible\'.')
-                  )
-              )
-            )
-
-            app$run_server()
-    - name: htmlAddress
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlAddress(children='5555 Avenue de Gaspe, Montreal QC H2T 2A3')
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlArea
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlImg(src = 'https://upload.wikimedia.org/wikipedia/commons/0/0c/PIA17351-ApparentSizes-MarsDeimosPhobos-EarthMoon.jpg',
-                        useMap = '#image-map'),
-                htmlMapEl(list(
-                  htmlArea(target='_blank',
-                           alt='Deimos',
-                           title='Deimos',
-                           href='https://en.wikipedia.org/wiki/Deimos_(moon)',
-                           coords='5,114,32,147',
-                           shape='rect'),
-                  htmlArea(target='_blank',
-                           alt='Phobos',
-                           title='Phobos',
-                           href='https://en.wikipedia.org/wiki/Phobos_(moon)',
-                           coords='113,196,32,103',
-                           shape='rect'),
-                  htmlArea(target='_blank',
-                           alt='Moon',
-                           title='Moon',
-                           href='https://en.wikipedia.org/wiki/Moon',
-                           coords='127,285,294,1',
-                           shape='rect')
-                  ),
-                  name = 'image-map'
-                ),
-                htmlDiv(children = 'Click on the image to visit a Wikipedia article',
-                        id = 'object-name')
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlArticle
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlArticle(list(
-                  htmlH2('Dash for R launched!'),
-                  htmlP('Dash is a user interface library for creating analytical web applications.\n
-                         Those who use R for data analysis, data exploration, visualization,\n
-                         modelling, instrument control, and reporting will find immediate use for Dash for R.'),
-                  htmlAside('Plotly is a technical computing company with offices in Montreal, Canada and Cambridge, Massachusetts.')
-                  )
-                )
-               )
-              )
-            )
-
-            app$run_server()
-    - name: htmlAside
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlArticle(list(
-                  htmlH2('Dash for R launched!'),
-                  htmlP('Dash is a user interface library for creating analytical web applications.\n
-                         Those who use R for data analysis, data exploration, visualization,\n
-                         modelling, instrument control, and reporting will find immediate use for Dash for R.'),
-                  htmlAside('Plotly is a technical computing company with offices in Montreal, Canada and Cambridge, Massachusetts.')
-                  )
-                )
-               )
-              )
-            )
-
-            app$run_server()
-    - name: htmlAudio
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlAudio(src='https://www.nasa.gov/62284main_onesmall2.wav',
-                          controls=TRUE,
-                          title='Apollo 11 - July 16, 1969 - Neil Armstrong')
-                  )
-               )
-            )
-
-            app$run_server()
-    - name: htmlB
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlB(children="This is a bold statement!"),
-                htmlP(children="This is not so bold.")
-                )
-               )
-            )
-
-            app$run_server()
-    - name: htmlBase
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlBase(href="https://www.w3schools.com/"),
-                htmlA(children="HTML base tag", href="tags/tag_base.asp")
-                )
-               )
-            )
-
-            app$run_server()
-    - name: htmlBasefont
-      dontrun: TRUE
-      code: |
-            # This feature is obsolete. It may still work in some
-            # browsers, but could stop working at any time. Try to
-            # avoid using this component.
-            #
-            # Instead, use CSS properties to set font, font-family,
-            # font-size and color.
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlBasefont(color="FF0000",
-                             face="Helvetica",
-                             size="+2"),
-                htmlP(children="If it works, this will be Helvetica but a couple point sizes larger.")
-                )
-               )
-            )
-
-            app$run_server()
-    - name: htmlBdi
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
+              app$layout(
                 htmlDiv(list(
-                    htmlP(children="The line below should render as 'Aladdin', but in Arabic script:"),
-                    htmlBdi(children="\U{0639}\U{0644}\U{0627}\U{0621} \U{0627}\U{0644}\U{062F}\U{064A}\U{0646}")
+                  htmlA(children='Link to external site',
+                        href='https://plotly.com',
+                        target='_blank')
+                  )
                 )
-                )
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
+    - name: htmlAbbr
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+              
+              app <- Dash$new()
+              
+              app$layout(
+                htmlDiv(list(
+                  htmlAbbr(children='Hello! htmlAbbr at work!',
+                  title='\U{1F50D} Hover over this line for a few seconds and see the text box appear...')
+                  )
+                )
+              )
+              
+              app$run_server()
+            }
+    - name: htmlAcronym
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlAcronym(children='ASAP',
+                  title='Mouse over these words to see the acronym for \'as soon as possible\'.')
+                    )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlAddress
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlAddress(children='5555 Avenue de Gaspe, Montreal QC H2T 2A3')
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlArea
+      dontrun: FALSE
+      code: |
+            # The URL below has been chunked to comply with CRAN
+            # requirements; the use of file.path is optional and not required
+            # for this component.
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app$layout(
+                htmlDiv(list(
+                  htmlImg(src = file.path('https://upload.wikimedia.org',
+                          'wikipedia/commons/0/0c',
+                          'PIA17351-ApparentSizes-MarsDeimosPhobos-EarthMoon.jpg',
+                          fsep = '/'),
+                          useMap = '#image-map'),
+                  htmlMapEl(list(
+                    htmlArea(target='_blank',
+                            alt='Deimos',
+                            title='Deimos',
+                            href='https://en.wikipedia.org/wiki/Deimos_(moon)',
+                            coords='5,114,32,147',
+                            shape='rect'),
+                    htmlArea(target='_blank',
+                            alt='Phobos',
+                            title='Phobos',
+                            href='https://en.wikipedia.org/wiki/Phobos_(moon)',
+                            coords='113,196,32,103',
+                            shape='rect'),
+                    htmlArea(target='_blank',
+                            alt='Moon',
+                            title='Moon',
+                            href='https://en.wikipedia.org/wiki/Moon',
+                            coords='127,285,294,1',
+                            shape='rect')
+                    ),
+                    name = 'image-map'
+                  ),
+                  htmlDiv(children = 'Click on the image to visit a Wikipedia article',
+                          id = 'object-name')
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlArticle
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlArticle(list(
+                    htmlH2('Dash for R launched!'),
+                    htmlP('Dash is a user interface library for creating analytical\n
+                          web applications. Those who use R for data analysis, data\n
+                          exploration, visualization, modelling, instrument control,\n
+                          and reporting will find immediate use for Dash for R.'),
+                    htmlAside('Plotly is a technical computing company with offices\n
+                               in Montreal, Canada and Cambridge, Massachusetts.')
+                    )
+                  )
+                )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlAside
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlArticle(list(
+                    htmlH2('Dash for R launched!'),
+                    htmlP('Dash is a user interface library for creating analytical\n
+                          web applications. Those who use R for data analysis, data\n
+                          exploration, visualization, modelling, instrument control,\n
+                          and reporting will find immediate use for Dash for R.'),
+                    htmlAside('Plotly is a technical computing company with offices\n
+                               in Montreal, Canada and Cambridge, Massachusetts.')
+                    )
+                  )
+                )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlAudio
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlAudio(src='https://www.nasa.gov/62284main_onesmall2.wav',
+                            controls=TRUE,
+                            title='Apollo 11 - July 16, 1969 - Neil Armstrong')
+                    )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlB
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlB(children="This is a bold statement!"),
+                  htmlP(children="This is not so bold.")
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlBase
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlBase(href="https://www.w3schools.com/"),
+                  htmlA(children="HTML base tag", href="tags/tag_base.asp")
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlBasefont
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              # This feature is obsolete. It may still work in some
+              # browsers, but could stop working at any time. Try to
+              # avoid using this component.
+              #
+              # Instead, use CSS properties to set font, font-family,
+              # font-size and color.
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlBasefont(color="FF0000",
+                              face="Helvetica",
+                              size="+2"),
+                  htmlP(children="If it works, this will be Helvetica but a couple point sizes larger.")
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlBdi
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                  htmlDiv(list(
+                      htmlP(children="This text is 'Aladdin', but in Arabic script:"),
+                      htmlBdi(children=paste0("\U{0639}\U{0644}\U{0627}\U{0621}",
+                                              "\U{0627}\U{0644}\U{062F}\U{064A}\U{0646}"))
+                  )
+                  )
+              )
+
+              app$run_server()
+            }
     - name: htmlBdo
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            # This element supports bidirectional text override.
-            # We can force text to render from right to left instead
-            # of left to right.
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              # This element supports bidirectional text override.
+              # We can force text to render from right to left instead
+              # of left to right.
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP(children="This text will print from left to right."),
-                htmlP(children="Below, we use bidirectional override to print right to left:"),
-                htmlBdo(children="This text will print from right to left.",
-                        dir="rtl")
-               )
+              app$layout(
+                htmlDiv(list(
+                  htmlP(children="This text will print from left to right."),
+                  htmlP(children="Below, we use bidirectional override to print right to left:"),
+                  htmlBdo(children="This text will print from right to left.",
+                          dir="rtl")
+                )
+                )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlBig
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            # The <big> tag is not supported in HTML5.
-            # Instead, use the font-size property in
-            # CSS to enlarge text.
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              # The <big> tag is not supported in HTML5.
+              # Instead, use the font-size property in
+              # CSS to enlarge text.
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP(children="This text will display in standard size."),
-                htmlBig(children="This text may or may not appear slightly larger.")
-               )
+              app$layout(
+                htmlDiv(list(
+                  htmlP(children="This text will display in standard size."),
+                  htmlBig(children="This text may or may not appear slightly larger.")
+                )
+                )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlBlink
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            # The blink tag is now obsolete and deprecated.
-            # It may not function properly in all browsers,
-            # and it may cease working without warning.
-            #
-            # This element is generally unsupported on all
-            # modern browser releases.
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              # The blink tag is now obsolete and deprecated.
+              # It may not function properly in all browsers,
+              # and it may cease working without warning.
+              #
+              # This element is generally unsupported on all
+              # modern browser releases.
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP(children="Here is a bit of text."),
-                htmlBlink(children="Here is a bit of blinking text.")
-               )
+              app$layout(
+                htmlDiv(list(
+                  htmlP(children="Here is a bit of text."),
+                  htmlBlink(children="Here is a bit of blinking text.")
+                )
+                )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlBlockquote
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {      
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP("Here is some text."),
-                htmlBlockquote(children=list(
-                   htmlP("And here is a quotation in block format.")
-                   )
+              app$layout(
+                htmlDiv(list(
+                  htmlP("Here is some text."),
+                  htmlBlockquote(children=list(
+                    htmlP("And here is a quotation in block format.")
+                    )
+                  )
                 )
-               )
+                )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlBr
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP("Here is some text."),
-                htmlBr(),
-                htmlP("Here is additional text."),
-                htmlBr(),
-                htmlP("See the gap in between the lines?")
+              app$layout(
+                htmlDiv(list(
+                  htmlP("Here is some text."),
+                  htmlBr(),
+                  htmlP("Here is additional text."),
+                  htmlBr(),
+                  htmlP("See the gap in between the lines?")
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlButton
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlButton("Click me!")
+              app$layout(
+                htmlDiv(list(
+                  htmlButton("Click me!")
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlCanvas
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            # this component requires JavaScript code to draw on the canvas
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              # this component requires JavaScript code to draw on the canvas
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlCanvas(id="canvas-component")
+              app$layout(
+                htmlDiv(list(
+                  htmlCanvas(id="canvas-component")
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlCaption
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlTable(list(
-                  htmlCaption("Elevations of a few Cascade Range volcanoes"),
-                  htmlThead(
-                    htmlTr(list(
-                      htmlTh("Mountain"),
-                      htmlTh("Elevation (m)"),
-                      htmlTh("Elevation (ft)")
+              app$layout(
+                htmlDiv(list(
+                  htmlTable(list(
+                    htmlCaption("Elevations of a few Cascade Range volcanoes"),
+                    htmlThead(
+                      htmlTr(list(
+                        htmlTh("Mountain"),
+                        htmlTh("Elevation (m)"),
+                        htmlTh("Elevation (ft)")
+                      )
+                    )),
+                    htmlTbody(list(
+                      htmlTr(list(
+                        htmlTd("Mount Rainier"),
+                        htmlTd("4,392"),
+                        htmlTd("14,411")
+                      )
+                      ),
+                      htmlTr(list(
+                        htmlTd("Mount Hood"),
+                        htmlTd("3,429"),
+                        htmlTd("11,249")
+                      )
+                      ),
+                      htmlTr(list(
+                        htmlTd("Lassen Peak"),
+                        htmlTd("3,187"),
+                        htmlTd("10,457")
+                      )
+                      ),
+                      htmlTr(list(
+                        htmlTd("Mount St. Helens"),
+                        htmlTd("2,549"),
+                        htmlTd("8,363")
+                      )
+                      )
                     )
-                  )),
-                  htmlTbody(list(
-                    htmlTr(list(
-                      htmlTd("Mount Rainier"),
-                      htmlTd("4,392"),
-                      htmlTd("14,411")
-                     )
-                    ),
-                    htmlTr(list(
-                      htmlTd("Mount Hood"),
-                      htmlTd("3,429"),
-                      htmlTd("11,249")
                     )
-                    ),
-                    htmlTr(list(
-                      htmlTd("Lassen Peak"),
-                      htmlTd("3,187"),
-                      htmlTd("10,457")
-                     )
-                    ),
-                    htmlTr(list(
-                      htmlTd("Mount St. Helens"),
-                      htmlTd("2,549"),
-                      htmlTd("8,363")
-                     )
-                    )
-                   )
+                  ), style = list(
+                        border = "1px black solid"
                   )
-                 ), style = list(
-                      border = "1px black solid"
-                 )
+                  )
                 )
               )
-             )
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlCenter
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlCenter("Centered text!")
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlCite
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlCite("Click me!")
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlCode
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(htmlDiv(list(
-              htmlCode(
-                children = 'cat("Hello world!")'
+              app$layout(
+                htmlDiv(list(
+                  htmlCenter("Centered text!")
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
+    - name: htmlCite
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlCite("Click me!")
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlCode
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(htmlDiv(list(
+                htmlCode(
+                  children = 'cat("Hello world!")'
+                    )
+                  )
+                )
+              )
+
+              app$run_server()
+            }
     - name: htmlCol
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            # Used within htmlColgroup to define columns.
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              # Used within htmlColgroup to define columns.
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlTable(list(
-                    htmlColgroup(
-                      list(
-                        htmlCol(span = 2, style = list("background-color"= "red"))
+              app$layout(
+                htmlDiv(list(
+                  htmlTable(list(
+                      htmlColgroup(
+                        list(
+                          htmlCol(span = 2, style = list("background-color"= "red"))
+                        )
+                      ),
+                      htmlTr(
+                        list(
+                          htmlTd("Cell A"),
+                          htmlTd("Cell B"),
+                          htmlTd("Cell C")
+                        )
                       )
-                    ),
-                    htmlTr(
-                      list(
-                        htmlTd("Cell A"),
-                        htmlTd("Cell B"),
-                        htmlTd("Cell C")
-                      )
-                    )
-                  ))
+                    ))
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlColgroup
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlTable(list(
-                    htmlColgroup(
-                      list(
-                        htmlCol(span = 2, style = list("background-color"= "red"))
+              app$layout(
+                htmlDiv(list(
+                  htmlTable(list(
+                      htmlColgroup(
+                        list(
+                          htmlCol(span = 2, style = list("background-color"= "red"))
+                        )
+                      ),
+                      htmlTr(
+                        list(
+                          htmlTd("Cell A"),
+                          htmlTd("Cell B"),
+                          htmlTd("Cell C")
+                        )
                       )
-                    ),
-                    htmlTr(
-                      list(
-                        htmlTd("Cell A"),
-                        htmlTd("Cell B"),
-                        htmlTd("Cell C")
-                      )
-                    )
-                  ))
+                    ))
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlCommand
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # This component is deprecated and its use is no longer recommended.
     - name: htmlContent
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # This feature is obsolete and no longer supported. It is recommended
             # that you use the htmlSlot component instead.
     - name: htmlData
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlUl(list(
-                    htmlLi(list(htmlData(value = 398, "First Element"))),
-                    htmlLi(list(htmlData(value = 399, "Second Element"))),
-                    htmlLi(list(htmlData(value = 400, "First Element")))
-                  ))
+              app$layout(
+                htmlDiv(list(
+                  htmlUl(list(
+                      htmlLi(list(htmlData(value = 398, "First Element"))),
+                      htmlLi(list(htmlData(value = 399, "Second Element"))),
+                      htmlLi(list(htmlData(value = 400, "First Element")))
+                    ))
+                  )
                 )
               )
-            )
 
-            # Include the following in a seperate CSS file in an
-            # `assets` directory in the root of your app.
-            #
-            # data:hover::after {
-            #   content: ' (ID ' attr(value) ')';
-            #   font-size: .7em;
-            # }
+              # Include the following in a seperate CSS file in an
+              # `assets` directory in the root of your app.
+              #
+              # data:hover::after {
+              #   content: ' (ID ' attr(value) ')';
+              #   font-size: .7em;
+              # }
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlDatalist
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
-            library(dashCoreComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+              library(dashCoreComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              dccInput(
-                placeholder = 'Enter here',
-                list = 'list-of-options'),
-              htmlDatalist(id = 'list-of-options',
-                children=list(
-                  htmlOption("Option 1"),
-                  htmlOption("Option 2"),
-                  htmlOption("Option 3")
+              app$layout(htmlDiv(list(
+                dccInput(
+                  placeholder = 'Enter here',
+                  list = 'list-of-options'),
+                htmlDatalist(id = 'list-of-options',
+                  children=list(
+                    htmlOption("Option 1"),
+                    htmlOption("Option 2"),
+                    htmlOption("Option 3")
+                      )
                     )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlDd
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlDl(
-                children= list(htmlDt("Dash for R"),
-                              htmlDd('HtmlDt and htmlDD must be used
-                                      within htmlDl'))
+              app$layout(htmlDiv(list(
+                htmlDl(
+                  children= list(htmlDt("Dash for R"),
+                                htmlDd('HtmlDt and htmlDD must be used
+                                        within htmlDl'))
+                    )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlDel
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlDel(
-                    children ="Deleted Hello"
+              app$layout(htmlDiv(list(
+                htmlDel(
+                      children ="Deleted Hello"
+                    )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlDetails
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlDetails(
-                  children = list(
-                    htmlSummary(
-                      children = "Within a details element, the summary can act as a clickable description"
-                    ),
-                    "And the rest is hidden until the summary is clicked"
+              app$layout(
+                htmlDiv(list(
+                  htmlDetails(
+                    children = list(
+                      htmlSummary(
+                        children = "Within a details element, the summary can act as a clickable description"
+                      ),
+                      "And the rest is hidden until the summary is clicked"
+                    )
+                  )
                   )
                 )
-                )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlDfn
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlDfn(
-                    children ="Hello"
+              app$layout(htmlDiv(list(
+                htmlDfn(
+                      children ="Hello"
+                    )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlDialog
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlDialog(
-                children = htmlP('Greetings')
+              app$layout(htmlDiv(list(
+                htmlDialog(
+                  children = htmlP('Greetings')
+                    )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlDiv
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            app <- Dash$new()
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+              
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlDiv('This Title is Wrapped inside an inner Div')
+              app$layout(
+                htmlDiv(list(
+                  htmlDiv('This Title is Wrapped inside an inner Div')
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlDl
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlDl(
-                children= list(htmlDt("Dash for R"),
-                              htmlDd('HtmlDt and htmlDD must be used
-                                      within htmlDl'))
+              app$layout(htmlDiv(list(
+                htmlDl(
+                  children= list(htmlDt("Dash for R"),
+                                htmlDd('HtmlDt and htmlDD must be used
+                                        within htmlDl'))
+                    )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlDt
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlDl(
-                children= list(htmlDt("Dash for R"),
-                              htmlDd('HtmlDt and htmlDD must be used
-                                      within htmlDl'))
+              app$layout(htmlDiv(list(
+                htmlDl(
+                  children= list(htmlDt("Dash for R"),
+                                htmlDd('HtmlDt and htmlDD must be used
+                                        within htmlDl'))
+                    )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlElement
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # This feature is obsolete. It may still work in some
             # browsers, but could stop working at any time. Try to
             # avoid using this component.
     - name: htmlEm
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlH1(list('Dash is a very ',
-                          htmlEm(' important '),
-                          'framework')
+              app$layout(htmlDiv(list(
+                htmlH1(list('Dash is a very ',
+                            htmlEm(' important '),
+                            'framework')
+                    )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlEmbed
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlEmbed(
-                src = 'https://archive.org/embed/VintageCartoonsSet1Mp4',
-                width = '500',
-                height = '500')
+              app$layout(htmlDiv(list(
+                htmlEmbed(
+                  src = 'https://archive.org/embed/VintageCartoonsSet1Mp4',
+                  width = '500',
+                  height = '500')
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlFieldset
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
-            library(dashCoreComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+              library(dashCoreComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlFieldset(
-                children = list('Choose your favorite Dash HTML component',
-                dccRadioItems(
-                  options=list(
-                    list("label'= "htmlDiv", "value'= "htmlDiv"),
-                    list("label'= "htmlBase", "value'= "htmlBase"),
-                    list("label'= "htmlArticle", "value'= "htmlArticle")
+              app$layout(htmlDiv(list(
+                htmlFieldset(
+                  children = list('Choose your favorite Dash HTML component',
+                  dccRadioItems(
+                    options=list(
+                      list("label"= "htmlDiv", "value"= "htmlDiv"),
+                      list("label"= "htmlBase", "value"= "htmlBase"),
+                      list("label"= "htmlArticle", "value"= "htmlArticle")
+                          )
                         )
                       )
                     )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlFigcaption
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlFigure(children = list(
-                htmlImg(src = 'https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png'),
-                htmlFigcaption(children = 'Plotly Logo')))
+              app$layout(htmlDiv(list(
+                htmlFigure(children = list(
+                  htmlImg(src = 'https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png'),
+                  htmlFigcaption(children = 'Plotly Logo')))
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlFigure
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlFigure(children = list(
-                htmlImg(src = 'https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png',
-                        width = '400',
-                        height = '150')
+              app$layout(htmlDiv(list(
+                htmlFigure(children = list(
+                  htmlImg(src = 'https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png',
+                          width = '400',
+                          height = '150')
+                      )
                     )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlFont
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # Starting with HTML 4, HTML does not convey styling information
             # anymore (outside the <style> element or the style attribute of each
             # element). CSS should be used for styling instead.
     - name: htmlFooter
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlFooter(list(
-                htmlH1('Dash'),
-                htmlLi('Pointer1'),
-                htmlLi('Pointer2')
+              app$layout(htmlDiv(list(
+                htmlFooter(list(
+                  htmlH1('Dash'),
+                  htmlLi('Pointer1'),
+                  htmlLi('Pointer2')
+                      )
                     )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlForm
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
-            library(dashCoreComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+              library(dashCoreComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlForm(children=list(
-                htmlP(children=list('Username: ', dccInput(type='text', id='username', placeholder='username'))),
-                htmlP(children=list('Password: ', dccInput(type='password', id='password', placeholder='password'))),
-                htmlButton(children=list('Login'), type='submit', id='login_button')
+              app$layout(htmlDiv(list(
+                htmlForm(children=list(
+                  htmlP(children=list('Username: ',
+                                      dccInput(type='text', 
+                                               id='username', 
+                                               placeholder='username'))),
+                  htmlP(children=list('Password: ',
+                                      dccInput(type='password', 
+                                               id='password',
+                                               placeholder='password'))),
+                  htmlButton(children=list('Login'), 
+                             type='submit', 
+                             id='login_button')
+                      )
                     )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()              
+            }
     - name: htmlFrame
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # htmlFrame is now deprecated. htmlIFrame is recommended instead.
     - name: htmlFrameset
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # htmlFrameset is now deprecated. htmlIFrame is recommended instead.
     - name: htmlHeader
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlHeader("This is a header"),
-                htmlP("And here is some text.")
-              )
-             )
-            )
-
-            app$run_server()
-    - name: htmlH1
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlH1(list(
-                  'Dash Html',
-                  htmlBr(), #We can customize
-                  htmlSpan('Dash', style = list('opacity' = '0.8')),
-                  htmlSpan(' Core')))
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlH2
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlH2(list(
-                  'Dash Html',
-                  htmlBr(), #We can customize
-                  htmlSpan('Dash', style = list('opacity' = '0.8')),
-                  htmlSpan(' Core')))
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlH3
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlH3(list(
-                  'Dash Html',
-                  htmlBr(), #We can customize
-                  htmlSpan('Dash', style = list('opacity' = '0.8')),
-                  htmlSpan(' Core')))
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlH4
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlH4(list(
-                  'Dash Html',
-                  htmlBr(), #We can customize
-                  htmlSpan('Dash', style = list('opacity' = '0.8')),
-                  htmlSpan(' Core')))
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlH5
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlH5(list(
-                  'Dash Html',
-                  htmlBr(), #We can customize
-                  htmlSpan('Dash', style = list('opacity' = '0.8')),
-                  htmlSpan(' Core')))
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlH6
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlH6(list(
-                  'Dash Html',
-                  htmlBr(), #We can customize
-                  htmlSpan('Dash', style = list('opacity' = '0.8')),
-                  htmlSpan(' Core')))
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlHgroup
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlHgroup(list(
-                  htmlH1('MultiLevel Title'),
-                  htmlHr(),
-                  htmlH2('Header')
-                    )
-                  )
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlHr
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
+              app$layout(
                 htmlDiv(list(
-                  htmlH1('Dash'),
-                  htmlHr(),
-                  htmlH2('Components')
+                  htmlHeader("This is a header"),
+                  htmlP("And here is some text.")
+                )
+              )
+              )
+
+              app$run_server()
+            }
+    - name: htmlH1
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {      
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlH1(list(
+                    'Dash Html',
+                    htmlBr(), #We can customize
+                    htmlSpan('Dash', style = list('opacity' = '0.8')),
+                    htmlSpan(' Core')))
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlH2
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlH2(list(
+                    'Dash Html',
+                    htmlBr(), #We can customize
+                    htmlSpan('Dash', style = list('opacity' = '0.8')),
+                    htmlSpan(' Core')))
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlH3
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlH3(list(
+                    'Dash Html',
+                    htmlBr(), #We can customize
+                    htmlSpan('Dash', style = list('opacity' = '0.8')),
+                    htmlSpan(' Core')))
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlH4
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlH4(list(
+                    'Dash Html',
+                    htmlBr(), #We can customize
+                    htmlSpan('Dash', style = list('opacity' = '0.8')),
+                    htmlSpan(' Core')))
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlH5
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlH5(list(
+                    'Dash Html',
+                    htmlBr(), #We can customize
+                    htmlSpan('Dash', style = list('opacity' = '0.8')),
+                    htmlSpan(' Core')))
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlH6
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlH6(list(
+                    'Dash Html',
+                    htmlBr(), #We can customize
+                    htmlSpan('Dash', style = list('opacity' = '0.8')),
+                    htmlSpan(' Core')))
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlHgroup
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlHgroup(list(
+                    htmlH1('MultiLevel Title'),
+                    htmlHr(),
+                    htmlH2('Header')
+                      )
                     )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
+    - name: htmlHr
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlDiv(list(
+                    htmlH1('Dash'),
+                    htmlHr(),
+                    htmlH2('Components')
+                      )
+                    )
+                  )
+                )
+              )
+
+              app$run_server()
+            }
     - name: htmlI
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                  htmlI('Italicized Text')
+              app$layout(
+                htmlDiv(list(
+                    htmlI('Italicized Text')
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlIframe
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlIframe(width = "600px", height = "600px",
-                        src = "https://dashr.plotly.com/")
+              app$layout(htmlDiv(list(
+                htmlIframe(width = "600px", height = "600px",
+                          src = "https://dashr.plotly.com/")
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlImg
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-                htmlImg(src ='https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png',
-                        height='200', width='400')
+              app$layout(htmlDiv(list(
+                  htmlImg(src ='https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png',
+                          height='200', width='400')
+                  )
                 )
               )
-            )
 
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlIns
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlIns('This text has been inserted')
+              app$layout(
+                htmlDiv(list(
+                  htmlIns('This text has been inserted')
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlIsindex
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # This component is deprecated and its use is no longer recommended.
     - name: htmlKbd
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP('Please Press: '),
-                htmlKbd(list(
-                  'Ctl + ',
-                  'Alt + ',
-                  'Delete'))
+              app$layout(
+                htmlDiv(list(
+                  htmlP('Please Press: '),
+                  htmlKbd(list(
+                    'Ctl + ',
+                    'Alt + ',
+                    'Delete'))
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlKeygen
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # This feature is obsolete. It may still work in some
             # browsers, but could stop working at any time. Try to
             # avoid using this component.
     - name: htmlLabel
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
-            library(dashCoreComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+              library(dashCoreComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(
-                htmlLabel(
-                  list(htmlDiv(list("Time points")),
-                      dccInput(
-                        id = "times-input",
-                        placeholder = "Enter a value...",
-                        type = "number",
-                        value = 1,
-                        min = 3,
-                        max = 999)
+              app$layout(
+                htmlDiv(
+                  htmlLabel(
+                    list(htmlDiv(list("Time points")),
+                        dccInput(
+                          id = "times-input",
+                          placeholder = "Enter a value...",
+                          type = "number",
+                          value = 1,
+                          min = 3,
+                          max = 999)
+                    )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlLegend
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
-            library(dashCoreComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+              library(dashCoreComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(htmlDiv(list(
-              htmlFieldset(
-                children = list(
-                                htmlLegend('Select your favorite component'),
-                                dccRadioItems(
-                                  options=list(
-                                    list("label'= "htmlDiv", "value'= "htmlDiv"),
-                                    list("label'= "htmlBase", "value'= "htmlBase"),
-                                    list("label'= "htmlArticle", "value'= "htmlArticle")
+              app$layout(htmlDiv(list(
+                htmlFieldset(
+                  children = list(
+                                  htmlLegend('Select your favorite component'),
+                                  dccRadioItems(
+                                    options=list(
+                                      list("label"= "htmlDiv", "value"= "htmlDiv"),
+                                      list("label"= "htmlBase", "value"= "htmlBase"),
+                                      list("label"= "htmlArticle", "value"= "htmlArticle")
+                          )
                         )
                       )
                     )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlLi
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlOl(list(
-                  htmlLi("Montreal"),
-                  htmlLi("Toronto"),
-                  htmlLi("Halifax")
-                )),
-                htmlUl(list(
-                  htmlLi("Montreal"),
-                  htmlLi("Toronto"),
-                  htmlLi("Halifax")
+              app$layout(
+                htmlDiv(list(
+                  htmlOl(list(
+                    htmlLi("Montreal"),
+                    htmlLi("Toronto"),
+                    htmlLi("Halifax")
+                  )),
+                  htmlUl(list(
+                    htmlLi("Montreal"),
+                    htmlLi("Toronto"),
+                    htmlLi("Halifax")
+                  ))
                 ))
-              ))
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlLink
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlLink(rel = "stylesheet", type = "text/css", href = "https://codepen.io/chriddyp/pen/bWLwgP.css")
-              ))
-            )
-
-            app$run_server()
-    - name: htmlListing
-      dontrun: TRUE
-      code: |
-            # Warning: The <listing> element was intended as a way to render HTML code on a page.
-            # It was never properly supported, and is now deprecated. Using <listing> will almost
-            # certainly result in unexpected results. Instead, use <code>, or place the content in
-            # a <div> with the appropriate CSS styling.
-
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlListing(list(
-                  htmlUl("A"),
-                  htmlUl("B"),
-                  htmlUl("C")
+              app$layout(
+                htmlDiv(list(
+                  htmlLink(rel = "stylesheet",
+                          type = "text/css",
+                          href = "https://codepen.io/chriddyp/pen/bWLwgP.css")
                 ))
-              ))
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
+    - name: htmlListing
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              # Warning: The <listing> element was intended as a way to render HTML code on a page.
+              # It was never properly supported, and is now deprecated. Using <listing> will almost
+              # certainly result in unexpected results. Instead, use <code>, or place the content in
+              # a <div> with the appropriate CSS styling.
+
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlListing(list(
+                    htmlUl("A"),
+                    htmlUl("B"),
+                    htmlUl("C")
+                  ))
+                ))
+              )
+
+              app$run_server()
+            }
     - name: htmlMain
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlMain(
-                  list(htmlH1("Benjamin Franklin"),
-                       htmlP("Benjamin Franklin was an American polymath
-                             and one of the Founding Fathers of the United States.
-                             Franklin was a leading author, printer, political theorist,
-                             politician, Freemason, postmaster, scientist, inventor,
-                             humorist, civic activist, statesman, and diplomat."))
-                )
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlMain(
+                    list(htmlH1("Benjamin Franklin"),
+                        htmlP("Benjamin Franklin was an American polymath
+                              and one of the Founding Fathers of the United States.
+                              Franklin was a leading author, printer, political theorist,
+                              politician, Freemason, postmaster, scientist, inventor,
+                              humorist, civic activist, statesman, and diplomat."))
+                  )
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlMapEl
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            # Note that htmlMapEl generates the <map> HTML element;
-            # for more information, please visit the link in this
-            # component's description.
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlImg(src = "https://upload.wikimedia.org/wikipedia/commons/0/0c/PIA17351-ApparentSizes-MarsDeimosPhobos-EarthMoon.jpg",
-                        useMap = "#image-map"),
-                htmlMapEl(list(
-                  htmlArea(target="_blank",
-                           alt="Deimos",
-                           title="Deimos",
-                           href="https://en.wikipedia.org/wiki/Deimos_(moon)",
-                           coords="5,114,32,147",
-                           shape="rect"),
-                  htmlArea(target="_blank",
-                           alt="Phobos",
-                           title="Phobos",
-                           href="https://en.wikipedia.org/wiki/Phobos_(moon)",
-                           coords="113,196,32,103",
-                           shape="rect"),
-                  htmlArea(target="_blank",
-                           alt="Moon",
-                           title="Moon",
-                           href="https://en.wikipedia.org/wiki/Moon",
-                           coords="127,285,294,1",
-                           shape="rect")
+            # The URL below has been chunked to comply with CRAN
+            # requirements; the use of file.path is optional and not required
+            # for this component.
+            if (interactive() && require(dash)) {
+              app$layout(
+                htmlDiv(list(
+                  htmlImg(src = file.path('https://upload.wikimedia.org',
+                          'wikipedia/commons/0/0c',
+                          'PIA17351-ApparentSizes-MarsDeimosPhobos-EarthMoon.jpg',
+                          fsep = '/'),
+                          useMap = '#image-map'),
+                  htmlMapEl(list(
+                    htmlArea(target='_blank',
+                            alt='Deimos',
+                            title='Deimos',
+                            href='https://en.wikipedia.org/wiki/Deimos_(moon)',
+                            coords='5,114,32,147',
+                            shape='rect'),
+                    htmlArea(target='_blank',
+                            alt='Phobos',
+                            title='Phobos',
+                            href='https://en.wikipedia.org/wiki/Phobos_(moon)',
+                            coords='113,196,32,103',
+                            shape='rect'),
+                    htmlArea(target='_blank',
+                            alt='Moon',
+                            title='Moon',
+                            href='https://en.wikipedia.org/wiki/Moon',
+                            coords='127,285,294,1',
+                            shape='rect')
+                    ),
+                    name = 'image-map'
                   ),
-                  name = "image-map"
-                ),
-                htmlDiv(children = "Click on the image to visit a Wikipedia article",
-                        id = "object-name")
+                  htmlDiv(children = 'Click on the image to visit a Wikipedia article',
+                          id = 'object-name')
+                  )
                 )
               )
-            )
-            app$run_server()
+
+              app$run_server()
+            }
     - name: htmlMark
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP(list(
-                  htmlMark("Plotly"),
-                  " develops online data analytics and visualization tools."
+              app$layout(
+                htmlDiv(list(
+                  htmlP(list(
+                    htmlMark("Plotly"),
+                    " develops online data analytics and visualization tools."
+                  ))
                 ))
-              ))
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlMarquee
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            # This feature is obsolete. It may still work in some
-            # browsers, but could stop working at any time. Try to
-            # avoid using this component.
+            if (interactive() && require(dash)) {
+              # This feature is obsolete. It may still work in some
+              # browsers, but could stop working at any time. Try to
+              # avoid using this component.
 
-            library(dash)
-            library(dashHtmlComponents)
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlMarquee("Here is some sliding text that uses htmlMarquee")
+              app$layout(
+                htmlDiv(list(
+                  htmlMarquee("Here is some sliding text that uses htmlMarquee")
 
-              ))
-            )
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlMeta
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP("The <meta> tag provides metadata about the HTML document.
-                      Metadata will not be displayed on the page, but will be machine parsable.
-                      To view meta tag the content of this page can be inspected."),
-                htmlMeta(name = "author", content = "Edward Tufte")
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlP("The <meta> tag provides metadata about the HTML document.
+                        Metadata will not be displayed on the page, but will be machine parsable.
+                        To view meta tag the content of this page can be inspected."),
+                  htmlMeta(name = "author", content = "Edward Tufte")
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlMeter
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlLabel("Sample Level Meter: "),
-                htmlMeter(id = "sample-meter",
-                          min = 0,
-                          max = 100,
-                          low = 33,
-                          high = 66,
-                          optimum = 80,
-                          value = 80
-                          )
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlLabel("Sample Level Meter: "),
+                  htmlMeter(id = "sample-meter",
+                            min = 0,
+                            max = 100,
+                            low = 33,
+                            high = 66,
+                            optimum = 80,
+                            value = 80
+                            )
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlMulticol
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # Warning: The <multicol> tag is obsolete, it might not work as intended.
             # Try to avoid using it.
     - name: htmlNav
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlNav(
-                  list(
-                    htmlA("Plotly", href = "https://plotly.com/"),
-                    '> ",
-                    htmlA("Dash", href = "https://plotly.com/dash"),
-                    '> ",
-                    htmlA("Request Trial", href = "https://go.plotly.com/dash-enterprise-trial")
+              app$layout(
+                htmlDiv(list(
+                  htmlNav(
+                    list(
+                      htmlA("Plotly", href = "https://plotly.com/"),
+                      "> ",
+                      htmlA("Dash", href = "https://plotly.com/dash"),
+                      "> ",
+                      htmlA("Request Trial", href = "https://go.plotly.com/dash-enterprise-trial")
+                    )
                   )
-                )
-              ))
-            )
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlNextid
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # This component is deprecated and its use is no longer recommended.
             # The <nextid> tag has been obsolete since HTML Version 3.2.
     - name: htmlNobr
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlNobr("Lorem ipsum dolor sit amet,
-                         consectetur adipiscing elit, sed do eiusmod
-                         tempor incididunt ut labore et dolore magna aliqua.
-                         Ut enim ad minim veniam, quis nostrud exercitation
-                         ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                         Duis aute irure dolor in reprehenderit in voluptate
-                         velit esse cillum dolore eu fugiat nulla pariatur.
-                         Excepteur sint occaecat cupidatat non proident,
-                         sunt in culpa qui officia deserunt mollit anim id est laborum."
-                )
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlNobr("Lorem ipsum dolor sit amet,
+                          consectetur adipiscing elit, sed do eiusmod
+                          tempor incididunt ut labore et dolore magna aliqua.
+                          Ut enim ad minim veniam, quis nostrud exercitation
+                          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                          Duis aute irure dolor in reprehenderit in voluptate
+                          velit esse cillum dolore eu fugiat nulla pariatur.
+                          Excepteur sint occaecat cupidatat non proident,
+                          sunt in culpa qui officia deserunt mollit anim id est laborum."
+                  )
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlNoscript
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # This component may be used in the index template to define
             # alternate content in browsers which have disabled scripts,
             # or in which scripts are not supported.
     - name: htmlObjectEl
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            # Note that htmlObjectEl generates the <object> HTML element;
-            # for more information, please visit the link in this
-            # component's description.
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              # Note that htmlObjectEl generates the <object> HTML element;
+              # for more information, please visit the link in this
+              # component's description.
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlObjectEl(
-                  width = 100,
-                  height = 97
-                  #data = "https://i.postimg.cc/tJd8PSVf/Plotly-logo-01-square.png"
-                )
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlObjectEl(
+                    width = 100,
+                    height = 97
+                    #data = "https://i.postimg.cc/tJd8PSVf/Plotly-logo-01-square.png"
+                  )
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlOl
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlOl(list(
-                  htmlLi("Un"),
-                  htmlLi("Deux"),
-                  htmlLi("Trois")
+              app$layout(
+                htmlDiv(list(
+                  htmlOl(list(
+                    htmlLi("Un"),
+                    htmlLi("Deux"),
+                    htmlLi("Trois")
+                  ))
                 ))
-              ))
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlOptgroup
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlLabel(
-                  htmlFor = "option-select", "Please select car brand/model: "
-                ),
-                htmlSelect(id = "option-select", list(
-                htmlOptgroup("Audi"), #label = "Audi"
-                htmlOption("TT"),
-                htmlOption("A4"),
-                htmlOptgroup("BMW"), #label = "BMW"
-                htmlOption("3 Series"),
-                htmlOption("5 Series")
+              app$layout(
+                htmlDiv(list(
+                  htmlLabel(
+                    htmlFor = "option-select", "Please select car brand/model: "
+                  ),
+                  htmlSelect(id = "option-select", list(
+                  htmlOptgroup("Audi"), #label = "Audi"
+                  htmlOption("TT"),
+                  htmlOption("A4"),
+                  htmlOptgroup("BMW"), #label = "BMW"
+                  htmlOption("3 Series"),
+                  htmlOption("5 Series")
+                  ))
                 ))
-              ))
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlOption
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlSelect(list(
-                  htmlOption("d'Artagnan"),
-                  htmlOption("Athos"),
-                  htmlOption("Porthos"),
-                  htmlOption("Aramis")
+              app$layout(
+                htmlDiv(list(
+                  htmlSelect(list(
+                    htmlOption("d'Artagnan"),
+                    htmlOption("Athos"),
+                    htmlOption("Porthos"),
+                    htmlOption("Aramis")
+                  ))
                 ))
-              ))
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlOutput
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            # This component works with htmlForm and htmlInput and may be used to present the result of an executed script.
+            # This component works with htmlForm and htmlInput 
+            # and may be used to present the result of an
+            # executed script.
     - name: htmlP
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP("The <p> tag defines a paragraph.")
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlP("The <p> tag defines a paragraph.")
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlParam
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP("The <param> element is used to specify the parameters that apply to
-                plugin-powered content embedded with an <object> element.
-                Read more: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param"),
-                htmlObjectEl(
-                  #data = "link-to-data-file"
-                  htmlParam(name = "controller", value = TRUE)
-                )
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlP("The <param> element is used to specify the parameters that apply to
+                  plugin-powered content embedded with an <object> element.
+                  Read more: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param"),
+                  htmlObjectEl(
+                    #data = "link-to-data-file"
+                    htmlParam(name = "controller", value = TRUE)
+                  )
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlPicture
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            # The URL below has been chunked to comply with CRAN
+            # requirements; the use of file.path is optional and not required
+            # for this component.
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlPicture(list(
-                  htmlSource(srcSet = "https://upload.wikimedia.org/wikipedia/commons/a/a7/Winter_and_the_City.jpg",
-                             media = "(min-width: 800px)"),
-                  htmlImg(src = "https://upload.wikimedia.org/wikipedia/commons/5/56/Summer_and_the_City.jpg"),
-                  htmlP("Resize screen to see image changing...")
+              app$layout(
+                htmlDiv(list(
+                  htmlPicture(list(
+                    htmlSource(srcSet = file.path("https://upload.wikimedia.org",
+                                                  "wikipedia/commons/a/a7",
+                                                  "Winter_and_the_City.jpg",
+                                                  fsep = "/"),
+                              media = "(min-width: 800px)"),
+                    htmlImg(src = file.path("https://upload.wikimedia.org",
+                                                  "wikipedia/commons/5/56",
+                                                  "Summer_and_the_City.jpg",
+                                                  fsep = "/")),
+                    htmlP("Resize screen to see image changing...")
+                  ))
                 ))
-              ))
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlPlaintext
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            # Warning: The <plaintext> tag is obsolete,
-            # it might not work as intended.
-            # Use the <pre> tag instead.
+            if (interactive() && require(dash)) {
+              # Warning: The <plaintext> tag is obsolete,
+              # it might not work as intended.
+              # Use the <pre> tag instead.
 
-            library(dash)
-            library(dashHtmlComponents)
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlPlaintext(),
-                htmlBr(),
-                htmlH4("The HTML Plaintext Element (<plaintext>) renders everything following
-                      the start tag as raw text, ignoring any following HTML. There is no closing tag,
-                      since everything after it is considered raw text.")
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlPlaintext(),
+                  htmlBr(),
+                  htmlH4("The HTML Plaintext Element (<plaintext>) renders everything following
+                        the start tag as raw text, ignoring any following HTML. There is no closing tag,
+                        since everything after it is considered raw text.")
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlPre
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlPre(
-                  "
-                  Text in a <pre> element is displayed
-                  in a fixed-width font (usually Courier),
-                  and it preserves both spaces and line breaks.
-                  "
-                )
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlPre(
+                    "
+                    Text in a <pre> element is displayed
+                    in a fixed-width font (usually Courier),
+                    and it preserves both spaces and line breaks.
+                    "
+                  )
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlProgress
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP("Below is an example of htmlProgress"),
-                htmlProgress(value = 80, max = 100)
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlP("Below is an example of htmlProgress"),
+                  htmlProgress(value = 80, max = 100)
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlQ
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlP(list(
-                "The <q> tag defines a short quotation: ",
-                htmlQ("This example text is wrapped in htmlQ")
+              app$layout(
+                htmlDiv(list(
+                  htmlP(list(
+                  "The <q> tag defines a short quotation: ",
+                  htmlQ("This example text is wrapped in htmlQ")
+                  ))
                 ))
-              ))
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlRb
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlRuby(list(
-                  "\U{6f22}",
-                  htmlRp("("),
-                  htmlRt("kan"),
-                  htmlRp(")")
-                )),
-                htmlRuby(list(
-                  "\U{5b57}",
-                  htmlRp("("),
-                  htmlRt("ji"),
-                  htmlRp(")")
+              app$layout(
+                htmlDiv(list(
+                  htmlRuby(list(
+                    "\U{6f22}",
+                    htmlRp("("),
+                    htmlRt("kan"),
+                    htmlRp(")")
+                  )),
+                  htmlRuby(list(
+                    "\U{5b57}",
+                    htmlRp("("),
+                    htmlRt("ji"),
+                    htmlRp(")")
+                  ))
                 ))
-              ))
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlRp
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlRuby(list(
-                  "\U{6f22}",
-                  htmlRp("("),
-                  htmlRt("kan"),
-                  htmlRp(")")
-                )),  
-                htmlRuby(list(
-                  "\U{5b57}",
-                  htmlRp("("),
-                  htmlRt("ji"),
-                  htmlRp(")")
+              app$layout(
+                htmlDiv(list(
+                  htmlRuby(list(
+                    "\U{6f22}",
+                    htmlRp("("),
+                    htmlRt("kan"),
+                    htmlRp(")")
+                  )),  
+                  htmlRuby(list(
+                    "\U{5b57}",
+                    htmlRp("("),
+                    htmlRt("ji"),
+                    htmlRp(")")
+                  ))   
                 ))   
-              ))   
-            )    
+              )    
 
-            app$run_server()    
+              app$run_server()
+            }
     - name: htmlRt
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlRuby(list(
-                  "\U{6f22}",
-                  htmlRp("("),
-                  htmlRt("kan"),
-                  htmlRp(")")
-                )),  
-                htmlRuby(list(
-                  "\U{5b57}",
-                  htmlRp("("),
-                  htmlRt("ji"),
-                  htmlRp(")")
+              app$layout(
+                htmlDiv(list(
+                  htmlRuby(list(
+                    "\U{6f22}",
+                    htmlRp("("),
+                    htmlRt("kan"),
+                    htmlRp(")")
+                  )),  
+                  htmlRuby(list(
+                    "\U{5b57}",
+                    htmlRp("("),
+                    htmlRt("ji"),
+                    htmlRp(")")
+                  ))   
                 ))   
-              ))   
-            )    
+              )    
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlRtc
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlRuby(list(
-                  "\U2661",
-                  htmlRtc(htmlRt('Heart"))
+              app$layout(
+                htmlDiv(list(
+                  htmlRuby(list(
+                    "\U2661",
+                    htmlRtc(htmlRt("Heart"))
+                  ))
                 ))
-              ))
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlRuby
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlRuby("\U{54d0}")
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlRuby("\U{54d0}")
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlS
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlS("htmlS  generates strikethrough text"),
-                htmlP(),
-                htmlB("htmlB  generates bold text")
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlS("htmlS  generates strikethrough text"),
+                  htmlP(),
+                  htmlB("htmlB  generates bold text")
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlSamp
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlSamp("htmlSamp formats text to computer program output.")
-              ))
-            )
+              app$layout(
+                htmlDiv(list(
+                  htmlSamp("htmlSamp formats text to computer program output.")
+                ))
+              )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlScript
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # This component is retained for compatibility reasons, but we suggest
             # using Dash's capability for embedding scripts within the assets folder
             # instead.
     - name: htmlSection
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlSection(
-                  children = list(
-                    htmlH1("This is a section title"),
-                    htmlDiv("This is some text within a section")
+              app$layout(
+                htmlDiv(list(
+                  htmlSection(
+                    children = list(
+                      htmlH1("This is a section title"),
+                      htmlDiv("This is some text within a section")
+                    )
+                  )
                   )
                 )
-                )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlSelect
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlSelect(
-                  children = list(
-                    htmlOption("This is an option in htmlSelect"),
-                    htmlOption("But you might want to check out dccDropdown as well"),
-                    htmlOption("dccDropdown is part of the dashCoreComponents library")
+              app$layout(
+                htmlDiv(list(
+                  htmlSelect(
+                    children = list(
+                      htmlOption("This is an option in htmlSelect"),
+                      htmlOption("But you might want to check out dccDropdown as well"),
+                      htmlOption("dccDropdown is part of the dashCoreComponents library")
+                    )
+                  )
                   )
                 )
-                )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlShadow
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # The Shadow element requires a browser that supports
             # Web Components. It is experimental and should be used
@@ -1949,454 +2163,491 @@ r_examples:
             #
             # For more information, please see the MDN link above.
     - name: htmlSlot
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # Please see https://mdn.github.io/web-components-examples/element-details/
             # and https://github.com/mdn/web-components-examples/tree/master/element-details
             # for a useful example of this element (with accompanying JavaScript) in action.
     - name: htmlSmall
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "This is normal text",
-                htmlBr(),
-                htmlSmall("And this is text in an htmlSmall component")
+              app$layout(
+                htmlDiv(list(
+                  "This is normal text",
+                  htmlBr(),
+                  htmlSmall("And this is text in an htmlSmall component")
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlSource
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            # The URL below has been chunked to comply with CRAN
+            # requirements; the use of file.path is optional and not required
+            # for this component.
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                  "Resize your browser window to see the image source change based based on the browser width",
-                  htmlBr(),
-                  htmlPicture(
-                    list(
-                      htmlSource(
-                        media = "(min-width: 1000px)",
-                        srcSet = "https://apod.nasa.gov/apod/image/1907/FishheadNebula_Pham_2401.jpg"
-                      ),
-                      htmlImg(
-                        src = "https://apod.nasa.gov/apod/image/1907/ngc3576_campbell_1824.jpg"
+              app$layout(
+                htmlDiv(list(
+                    "Resize your browser window to see the image source change based on the browser width",
+                    htmlBr(),
+                    htmlPicture(
+                      list(
+                        htmlSource(
+                          media = "(min-width: 1000px)",
+                          srcSet = "https://apod.nasa.gov/apod/image/1907/FishheadNebula_Pham_2401.jpg"
+                        ),
+                        htmlImg(
+                          src = "https://apod.nasa.gov/apod/image/1907/ngc3576_campbell_1824.jpg"
+                        )
                       )
                     )
                   )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()              
+            }
     - name: htmlSpacer
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # This component provides an HTML element that is now obsolete
             # and not supported by modern web browsers; it is retained for
             # backwards compatibility.
     - name: htmlSpan
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "This is some text",
-                htmlBr(),
-                htmlSpan(
-                  children = "And some text within an italicized span",
-                  style = list(fontStyle = "italic")
-                )
+              app$layout(
+                htmlDiv(list(
+                  "This is some text",
+                  htmlBr(),
+                  htmlSpan(
+                    children = "And some text within an italicized span",
+                    style = list(fontStyle = "italic")
+                  )
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlStrike
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "This is normal text",
-                htmlStrike("Text within an htmlStrike element will be stricken out")
+              app$layout(
+                htmlDiv(list(
+                  "This is normal text",
+                  htmlStrike("Text within an htmlStrike element will be stricken out")
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlStrong
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "This is normal text",
-                htmlBr(),
-                htmlStrong("Text within an htmlStrong element will be Bold")
+              app$layout(
+                htmlDiv(list(
+                  "This is normal text",
+                  htmlBr(),
+                  htmlStrong("Text within an htmlStrong element will be Bold")
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlSub
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "This is normal text ",
-                htmlSub("And this is subscript text within an htmlSub")
+              app$layout(
+                htmlDiv(list(
+                  "This is normal text ",
+                  htmlSub("And this is subscript text within an htmlSub")
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlSummary
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlDetails(
-                  children = list(
-                    htmlSummary(
-                      children = "Within a details element, the summary can act as a clickable description"
-                    ),
-                    "And the rest is hidden until the summary is clicked"
+              app$layout(
+                htmlDiv(list(
+                  htmlDetails(
+                    children = list(
+                      htmlSummary(
+                        children = "Within a details element, the summary can act as a clickable description"
+                      ),
+                      "And the rest is hidden until the summary is clicked"
+                    )
+                  )
                   )
                 )
-                )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlSup
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "This is normal text",
-                htmlSup("And this is superscript text within an htmlSup")
+              app$layout(
+                htmlDiv(list(
+                  "This is normal text",
+                  htmlSup("And this is superscript text within an htmlSup")
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlTable
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "You can create a table with htmlTable:",
-                htmlBr(),
-                htmlTable(
-                  list(
-                    htmlTr(
-                      list(
-                        htmlTh("Table Header 1"),
-                        htmlTh("Table Header 2")
-                      )
-                    ),
-                    htmlTr(
-                      list(
-                        htmlTd("row 1 under Header 1"),
-                        htmlTd("row 1 under Header 2")
+              app$layout(
+                htmlDiv(list(
+                  "You can create a table with htmlTable:",
+                  htmlBr(),
+                  htmlTable(
+                    list(
+                      htmlTr(
+                        list(
+                          htmlTh("Table Header 1"),
+                          htmlTh("Table Header 2")
+                        )
+                      ),
+                      htmlTr(
+                        list(
+                          htmlTd("row 1 under Header 1"),
+                          htmlTd("row 1 under Header 2")
+                        )
                       )
                     )
                   )
-                )
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlTbody
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "Within an htmlTable, you can specify the rows that go in the body of the table with htmlTbody",
-                htmlBr(),
-                htmlTable(
-                  list(
-                    htmlThead(
-                      htmlTr(
-                        htmlTh("This is in the header of the table")
-                      )
-                    ),
-                    htmlTbody(
-                      htmlTr(
-                        htmlTd("This is in the body of the table")
-                      )
-                    ),
-                    htmlTfoot(
-                      htmlTr(
-                        htmlTd("This is in the footer of the table")
+              app$layout(
+                htmlDiv(list(
+                  "Within an htmlTable, htmlTbody specifies rows for the table body",
+                  htmlBr(),
+                  htmlTable(
+                    list(
+                      htmlThead(
+                        htmlTr(
+                          htmlTh("This is in the header of the table")
+                        )
+                      ),
+                      htmlTbody(
+                        htmlTr(
+                          htmlTd("This is in the body of the table")
+                        )
+                      ),
+                      htmlTfoot(
+                        htmlTr(
+                          htmlTd("This is in the footer of the table")
+                        )
                       )
                     )
                   )
-                )
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlTd
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "Within an htmlTable, individual cells can be made with htmlTd",
-                htmlBr(),
-                htmlTable(
-                  list(
-                    htmlTr(
-                      list(
-                        htmlTh("Header 1"),
-                        htmlTh("Header 2")
-                      )
-                    ),
-                    htmlTr(
-                      list(
-                        htmlTd("this is a cell"),
-                        htmlTd("this is another cell")
+              app$layout(
+                htmlDiv(list(
+                  "Within an htmlTable, individual cells can be made with htmlTd",
+                  htmlBr(),
+                  htmlTable(
+                    list(
+                      htmlTr(
+                        list(
+                          htmlTh("Header 1"),
+                          htmlTh("Header 2")
+                        )
+                      ),
+                      htmlTr(
+                        list(
+                          htmlTd("this is a cell"),
+                          htmlTd("this is another cell")
+                        )
                       )
                     )
                   )
-                )
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlTemplate
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "You can create an HTML template to be populated later via js",
-                htmlBr(),
-                htmlTable(
-                  id = "myTable",
-                  htmlTr(
-                    list(
-                      htmlTh("Header 1"),
-                      htmlTh("Header 2")
-                    )
-                  )
-                ),
-                htmlTemplate(
-                  id = "myRowTemplate",
-                  htmlTr(
-                    list(
-                      htmlTd(className = "someRowValue"),
-                      htmlTd()
-                    )
-                  )
-                )
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlTextarea
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlTextarea(
-                  rows = 4, cols = 50,
-                  children = "A text area allows users to input text"
-                )
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlTfoot
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                "Within an htmlTable, you can create footer rows with htmlTfoot",
-                htmlBr(),
-                htmlTable(
-                  list(
-                    htmlThead(
-                      htmlTr(
-                        htmlTh("This is in the header of the table")
-                      )
-                    ),
-                    htmlTbody(
-                      htmlTr(
-                        htmlTd("This is in the body of the table")
-                      )
-                    ),
-                    htmlTfoot(
-                      htmlTr(
-                        htmlTd("This is in the footer of the table")
-                      )
-                    )
-                  )
-                )
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlTh
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlTable(
-                  list(
-                    # the following row contains headers
+              app$layout(
+                htmlDiv(list(
+                  "You can create an HTML template to be populated later via js",
+                  htmlBr(),
+                  htmlTable(
+                    id = "myTable",
                     htmlTr(
                       list(
                         htmlTh("Header 1"),
                         htmlTh("Header 2")
                       )
                     )
-                  )
-                )
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlThead
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                "Within an htmlTable, you can create a header with htmlThead",
-                htmlBr(),
-                htmlTable(
-                  list(
-                    htmlThead(
-                      htmlTr(
-                        htmlTh("This is in the header of the table")
-                      )
-                    ),
-                    htmlTbody(
-                      htmlTr(
-                        htmlTd("This is in the body of the table")
-                      )
-                    ),
-                    htmlTfoot(
-                      htmlTr(
-                        htmlTd("This is in the footer of the table")
+                  ),
+                  htmlTemplate(
+                    id = "myRowTemplate",
+                    htmlTr(
+                      list(
+                        htmlTd(className = "someRowValue"),
+                        htmlTd()
                       )
                     )
                   )
-                )
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlTime
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlP(
-                  list(
-                    "It might be useful to wrap dates like ",
-                    htmlTime(dateTime = "2019-07-29", children = "July 29th"),
-                    " in an htmlTime to make your datetime strings machine-readable."
                   )
                 )
+              )
+
+              app$run_server()
+            }
+    - name: htmlTextarea
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlTextarea(
+                    rows = 4, cols = 50,
+                    children = "A text area allows users to input text"
+                  )
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
+    - name: htmlTfoot
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  "Within an htmlTable, you can create footer rows with htmlTfoot",
+                  htmlBr(),
+                  htmlTable(
+                    list(
+                      htmlThead(
+                        htmlTr(
+                          htmlTh("This is in the header of the table")
+                        )
+                      ),
+                      htmlTbody(
+                        htmlTr(
+                          htmlTd("This is in the body of the table")
+                        )
+                      ),
+                      htmlTfoot(
+                        htmlTr(
+                          htmlTd("This is in the footer of the table")
+                        )
+                      )
+                    )
+                  )
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlTh
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlTable(
+                    list(
+                      # the following row contains headers
+                      htmlTr(
+                        list(
+                          htmlTh("Header 1"),
+                          htmlTh("Header 2")
+                        )
+                      )
+                    )
+                  )
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlThead
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  "Within an htmlTable, you can create a header with htmlThead",
+                  htmlBr(),
+                  htmlTable(
+                    list(
+                      htmlThead(
+                        htmlTr(
+                          htmlTh("This is in the header of the table")
+                        )
+                      ),
+                      htmlTbody(
+                        htmlTr(
+                          htmlTd("This is in the body of the table")
+                        )
+                      ),
+                      htmlTfoot(
+                        htmlTr(
+                          htmlTd("This is in the footer of the table")
+                        )
+                      )
+                    )
+                  )
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlTime
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlP(
+                    list(
+                      "It might be useful to wrap dates like ",
+                      htmlTime(dateTime = "2019-07-29", children = "July 29th"),
+                      " in an htmlTime to make your datetime strings machine-readable."
+                    )
+                  )
+                  )
+                )
+              )
+
+              app$run_server()
+            }
     - name: htmlTitle
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
             # This component's effects will be overridden by the index
             # template in Dash for R. We suggest using Dash's API to
@@ -2404,175 +2655,208 @@ r_examples:
             #
             # app$title('My page title')
     - name: htmlTr
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "Within an htmlTable, individual rows can be made with htmlTr",
-                htmlBr(),
-                htmlTable(
-                  list(
-                    # the following row contains headers
-                    htmlTr(
-                      list(
-                        htmlTh("Header 1"),
-                        htmlTh("Header 2")
-                      )
-                    ),
-                    # the following row contains cells
-                    htmlTr(
-                      list(
-                        htmlTd("this is a cell"),
-                        htmlTd("this is another cell")
+              app$layout(
+                htmlDiv(list(
+                  "Within an htmlTable, individual rows can be made with htmlTr",
+                  htmlBr(),
+                  htmlTable(
+                    list(
+                      # the following row contains headers
+                      htmlTr(
+                        list(
+                          htmlTh("Header 1"),
+                          htmlTh("Header 2")
+                        )
+                      ),
+                      # the following row contains cells
+                      htmlTr(
+                        list(
+                          htmlTd("this is a cell"),
+                          htmlTd("this is another cell")
+                        )
                       )
                     )
                   )
-                )
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlTrack
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlVideo(children = list(
-                  htmlSource(src = 'https://interactive-examples.mdn.mozilla.net/media/examples/friday.mp4', type = 'video/mp4'),
-                  htmlTrack(kind = 'captions', srcLang = 'en', src = 'https://interactive-examples.mdn.mozilla.net/media/examples/friday.vtt', default = 'default', label = 'English')
-                ),
-                controls = TRUE
-               )
-              )
-             )
-            )
-
-            app$run_server()
-    - name: htmlU
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                htmlU("Wrap your text in htmlU to have it underlined")
-                )
-              )
-            )
-
-            app$run_server()
-    - name: htmlUl
-      dontrun: TRUE
-      code: |
-            library(dash)
-            library(dashHtmlComponents)
-
-            app <- Dash$new()
-
-            app$layout(
-              htmlDiv(list(
-                "You can make an unordered list with htmlUl",
-                htmlBr(),
-                htmlUl(
-                  children = list(
-                    htmlLi("Some item"),
-                    htmlLi("Some other item")
                   )
                 )
+              )
+
+              app$run_server()
+            }
+    - name: htmlTrack
+      dontrun: FALSE
+      code: |
+            # The URL below has been chunked to comply with CRAN
+            # requirements; the use of file.path is optional and not required
+            # for this component.
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlVideo(children = list(
+                    htmlSource(src = file.path("https://interactive-examples.mdn.mozilla.net",
+                                              "media/examples",
+                                              "friday.mp4",
+                                              fsep = "/"), 
+                              type = 'video/mp4'),
+                    htmlTrack(kind = 'captions',
+                              srcLang = 'en',
+                              src = file.path("https://interactive-examples.mdn.mozilla.net",
+                                              "media/examples",
+                                              "friday.vtt",
+                                              fsep = "/"), 
+                              default = 'default',
+                              label = 'English')
+                  ),
+                  controls = TRUE
+                )
                 )
               )
-            )
+              )
 
-            app$run_server()
+              app$run_server()
+            }
+    - name: htmlU
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  htmlU("Wrap your text in htmlU to have it underlined")
+                  )
+                )
+              )
+
+              app$run_server()
+            }
+    - name: htmlUl
+      dontrun: FALSE
+      code: |
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
+
+              app <- Dash$new()
+
+              app$layout(
+                htmlDiv(list(
+                  "You can make an unordered list with htmlUl",
+                  htmlBr(),
+                  htmlUl(
+                    children = list(
+                      htmlLi("Some item"),
+                      htmlLi("Some other item")
+                    )
+                  )
+                  )
+                )
+              )
+
+              app$run_server()
+            }
     - name: htmlVar
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "You can use htmlVar to represent the name of a variable",
-                htmlBr(),
-                htmlVar("myVariable")
+              app$layout(
+                htmlDiv(list(
+                  "You can use htmlVar to represent the name of a variable",
+                  htmlBr(),
+                  htmlVar("myVariable")
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlVideo
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlVideo(
-                  src = "https://ia800303.us.archive.org/18/items/bacteria_friend_and_foe/bacteria_friend_and_foe_512kb.mp4",
-                  controls = TRUE,
-                  title = "Bacteria: Friend and Foe"
-                )
+              app$layout(
+                htmlDiv(list(
+                  htmlVideo(
+                    src = file.path('https://ia800303.us.archive.org',
+                          '18/items/bacteria_friend_and_foe',
+                          'bacteria_friend_and_foe_512kb.mp4',
+                          fsep = '/'),
+                    controls = TRUE,
+                    title = "Bacteria: Friend and Foe"
+                  )
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlWbr
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                "In a long string, it might be a good idea to add an htmlWbr to specify word breaks",
-                htmlP("Thisverylongstringwithnowhitespaceswon'tlookverygood"),
-                htmlWbr(),
-                htmlP("butatleastyoucanspecifya'natural'placeforthestringtobebrokenup")
+              app$layout(
+                htmlDiv(list(
+                  "In a long string, it might be a good idea to add an htmlWbr to specify word breaks",
+                  htmlP("Thisverylongstringwithnowhitespaceswon'tlookverygood"),
+                  htmlWbr(),
+                  htmlP("butatleastyoucanspecifya'natural'placeforthestringtobebrokenup")
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }
     - name: htmlXmp
-      dontrun: TRUE
+      dontrun: FALSE
       code: |
-            library(dash)
-            library(dashHtmlComponents)
+            if (interactive() && require(dash)) {
+              library(dash)
+              library(dashHtmlComponents)
 
-            app <- Dash$new()
+              app <- Dash$new()
 
-            app$layout(
-              htmlDiv(list(
-                htmlXmp("xmp elements will be rendered in monospace font"),
-                htmlXmp("Note that this element is obsolete in HTML5"),
-                htmlA(
-                  "See this for more details",
-                  href = "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/xmp"
-                )
+              app$layout(
+                htmlDiv(list(
+                  htmlXmp("xmp elements will be rendered in monospace font"),
+                  htmlXmp("Note that this element is obsolete in HTML5"),
+                  htmlA(
+                    "See this for more details",
+                    href = "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/xmp"
+                  )
+                  )
                 )
               )
-            )
 
-            app$run_server()
+              app$run_server()
+            }

--- a/man/dashHtmlComponents-package.Rd
+++ b/man/dashHtmlComponents-package.Rd
@@ -2,9 +2,9 @@
 \docType{package}
 \name{dashHtmlComponents-package}
 \alias{dashHtmlComponents}
-\title{Vanilla HTML Components for Dash}
+\title{Vanilla HTML Components for 'Dash'}
 \description{
-Dash is a web application framework that provides pure Python and R abstraction around HTML, CSS, and JavaScript. Instead of writing HTML or using an HTML templating engine, you compose your layout using R functions within the dashHtmlComponents package. The source for this package is on GitHub: plotly/dash-html-components.
+'Dash' is a web application framework that provides pure Python and R abstraction around HTML, CSS, and JavaScript. Instead of writing HTML or using an HTML templating engine, you compose your layout using R functions within the 'dashHtmlComponents' package. The source for this package is on GitHub: plotly/dash-html-components.
 }
 \author{
 \strong{Maintainer}: Ryan Patrick Kyle <ryan@plotly.com>

--- a/man/htmlA.Rd
+++ b/man/htmlA.Rd
@@ -10,11 +10,14 @@ A is a wrapper for the <a> HTML5 element. For detailed attribute info see: https
 }
 
 \usage{
-htmlA(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, download=NULL, href=NULL, hrefLang=NULL, media=NULL, rel=NULL,
-shape=NULL, target=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlA(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, download=NULL,
+href=NULL, hrefLang=NULL, media=NULL, rel=NULL, shape=NULL,
+target=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -80,22 +83,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlA(children='Link to external site',
-          href='https://plotly.com',
-          target='_blank')
+  app$layout(
+    htmlDiv(list(
+      htmlA(children='Link to external site',
+            href='https://plotly.com',
+            target='_blank')
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlAbbr.Rd
+++ b/man/htmlAbbr.Rd
@@ -10,10 +10,12 @@ Abbr is a wrapper for the <abbr> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlAbbr(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlAbbr(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
-
-app <- Dash$new()
-
-app$layout(
-   htmlDiv(list(
-     htmlAbbr(children='Hello! htmlAbbr at work!',
-              title='\U{1F50D} Hover over this line for a few seconds and see the text box appear...')
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
+  
+  app <- Dash$new()
+  
+  app$layout(
+    htmlDiv(list(
+      htmlAbbr(children='Hello! htmlAbbr at work!',
+      title='\U{1F50D} Hover over this line for a few seconds and see the text box appear...')
       )
-   )
-)
-
-app$run_server()
-}}
+    )
+  )
+  
+  app$run_server()
+}
+}

--- a/man/htmlAcronym.Rd
+++ b/man/htmlAcronym.Rd
@@ -10,10 +10,12 @@ Acronym is a wrapper for the <acronym> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlAcronym(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlAcronym(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlAcronym(children='ASAP',
-    title='Mouse over these words to see the acronym for \'as soon as possible\'.')
-      )
+  app$layout(
+    htmlDiv(list(
+      htmlAcronym(children='ASAP',
+      title='Mouse over these words to see the acronym for \'as soon as possible\'.')
+        )
+    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlAddress.Rd
+++ b/man/htmlAddress.Rd
@@ -10,10 +10,12 @@ Address is a wrapper for the <address> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlAddress(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlAddress(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,20 +67,28 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlAddress(children='5555 Avenue de Gaspe, Montreal QC H2T 2A3')
+  app$layout(
+    htmlDiv(list(
+      htmlAddress(children='5555 Avenue de Gaspe, Montreal QC H2T 2A3')
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlArea.Rd
+++ b/man/htmlArea.Rd
@@ -10,12 +10,14 @@ Area is a wrapper for the <area> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlArea(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, alt=NULL, coords=NULL, download=NULL, href=NULL, hrefLang=NULL,
-media=NULL, rel=NULL, shape=NULL, target=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlArea(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, alt=NULL,
+coords=NULL, download=NULL, href=NULL, hrefLang=NULL,
+media=NULL, rel=NULL, shape=NULL, target=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -85,45 +87,57 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+# The URL below has been chunked to comply with CRAN
+# requirements; the use of file.path is optional and not required
+# for this component.
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
-
-app$layout(
-  htmlDiv(list(
-    htmlImg(src = 'https://upload.wikimedia.org/wikipedia/commons/0/0c/PIA17351-ApparentSizes-MarsDeimosPhobos-EarthMoon.jpg',
-            useMap = '#image-map'),
-    htmlMapEl(list(
-      htmlArea(target='_blank',
-               alt='Deimos',
-               title='Deimos',
-               href='https://en.wikipedia.org/wiki/Deimos_(moon)',
-               coords='5,114,32,147',
-               shape='rect'),
-      htmlArea(target='_blank',
-               alt='Phobos',
-               title='Phobos',
-               href='https://en.wikipedia.org/wiki/Phobos_(moon)',
-               coords='113,196,32,103',
-               shape='rect'),
-      htmlArea(target='_blank',
-               alt='Moon',
-               title='Moon',
-               href='https://en.wikipedia.org/wiki/Moon',
-               coords='127,285,294,1',
-               shape='rect')
+  app$layout(
+    htmlDiv(list(
+      htmlImg(src = file.path('https://upload.wikimedia.org',
+              'wikipedia/commons/0/0c',
+              'PIA17351-ApparentSizes-MarsDeimosPhobos-EarthMoon.jpg',
+              fsep = '/'),
+              useMap = '#image-map'),
+      htmlMapEl(list(
+        htmlArea(target='_blank',
+                alt='Deimos',
+                title='Deimos',
+                href='https://en.wikipedia.org/wiki/Deimos_(moon)',
+                coords='5,114,32,147',
+                shape='rect'),
+        htmlArea(target='_blank',
+                alt='Phobos',
+                title='Phobos',
+                href='https://en.wikipedia.org/wiki/Phobos_(moon)',
+                coords='113,196,32,103',
+                shape='rect'),
+        htmlArea(target='_blank',
+                alt='Moon',
+                title='Moon',
+                href='https://en.wikipedia.org/wiki/Moon',
+                coords='127,285,294,1',
+                shape='rect')
+        ),
+        name = 'image-map'
       ),
-      name = 'image-map'
-    ),
-    htmlDiv(children = 'Click on the image to visit a Wikipedia article',
-            id = 'object-name')
+      htmlDiv(children = 'Click on the image to visit a Wikipedia article',
+              id = 'object-name')
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlArticle.Rd
+++ b/man/htmlArticle.Rd
@@ -10,10 +10,12 @@ Article is a wrapper for the <article> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlArticle(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlArticle(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,27 +67,37 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlArticle(list(
-      htmlH2('Dash for R launched!'),
-      htmlP('Dash is a user interface library for creating analytical web applications.\n
-             Those who use R for data analysis, data exploration, visualization,\n
-             modelling, instrument control, and reporting will find immediate use for Dash for R.'),
-      htmlAside('Plotly is a technical computing company with offices in Montreal, Canada and Cambridge, Massachusetts.')
+  app$layout(
+    htmlDiv(list(
+      htmlArticle(list(
+        htmlH2('Dash for R launched!'),
+        htmlP('Dash is a user interface library for creating analytical\n
+              web applications. Those who use R for data analysis, data\n
+              exploration, visualization, modelling, instrument control,\n
+              and reporting will find immediate use for Dash for R.'),
+        htmlAside('Plotly is a technical computing company with offices\n
+                   in Montreal, Canada and Cambridge, Massachusetts.')
+        )
       )
     )
-   )
+    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlAside.Rd
+++ b/man/htmlAside.Rd
@@ -10,10 +10,12 @@ Aside is a wrapper for the <aside> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlAside(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlAside(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,27 +67,37 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlArticle(list(
-      htmlH2('Dash for R launched!'),
-      htmlP('Dash is a user interface library for creating analytical web applications.\n
-             Those who use R for data analysis, data exploration, visualization,\n
-             modelling, instrument control, and reporting will find immediate use for Dash for R.'),
-      htmlAside('Plotly is a technical computing company with offices in Montreal, Canada and Cambridge, Massachusetts.')
+  app$layout(
+    htmlDiv(list(
+      htmlArticle(list(
+        htmlH2('Dash for R launched!'),
+        htmlP('Dash is a user interface library for creating analytical\n
+              web applications. Those who use R for data analysis, data\n
+              exploration, visualization, modelling, instrument control,\n
+              and reporting will find immediate use for Dash for R.'),
+        htmlAside('Plotly is a technical computing company with offices\n
+                   in Montreal, Canada and Cambridge, Massachusetts.')
+        )
       )
     )
-   )
+    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlAudio.Rd
+++ b/man/htmlAudio.Rd
@@ -10,12 +10,14 @@ Audio is a wrapper for the <audio> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlAudio(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, autoPlay=NULL, controls=NULL, crossOrigin=NULL, loop=NULL,
-muted=NULL, preload=NULL, src=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlAudio(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, autoPlay=NULL,
+controls=NULL, crossOrigin=NULL, loop=NULL, muted=NULL,
+preload=NULL, src=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -81,22 +83,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlAudio(src='https://www.nasa.gov/62284main_onesmall2.wav',
-              controls=TRUE,
-              title='Apollo 11 - July 16, 1969 - Neil Armstrong')
-      )
-   )
-)
+  app$layout(
+    htmlDiv(list(
+      htmlAudio(src='https://www.nasa.gov/62284main_onesmall2.wav',
+                controls=TRUE,
+                title='Apollo 11 - July 16, 1969 - Neil Armstrong')
+        )
+    )
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlB.Rd
+++ b/man/htmlB.Rd
@@ -10,10 +10,12 @@ B is a wrapper for the <b> HTML5 element. For detailed attribute info see: https
 }
 
 \usage{
-htmlB(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlB(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlB(children="This is a bold statement!"),
-    htmlP(children="This is not so bold.")
+  app$layout(
+    htmlDiv(list(
+      htmlB(children="This is a bold statement!"),
+      htmlP(children="This is not so bold.")
+      )
     )
-   )
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlBase.Rd
+++ b/man/htmlBase.Rd
@@ -10,11 +10,13 @@ Base is a wrapper for the <base> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlBase(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, href=NULL, target=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlBase(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, href=NULL,
+target=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -70,21 +72,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlBase(href="https://www.w3schools.com/"),
-    htmlA(children="HTML base tag", href="tags/tag_base.asp")
+  app$layout(
+    htmlDiv(list(
+      htmlBase(href="https://www.w3schools.com/"),
+      htmlA(children="HTML base tag", href="tags/tag_base.asp")
+      )
     )
-   )
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlBasefont.Rd
+++ b/man/htmlBasefont.Rd
@@ -10,10 +10,12 @@ Basefont is a wrapper for the <basefont> HTML5 element. For detailed attribute i
 }
 
 \usage{
-htmlBasefont(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlBasefont(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,29 +67,37 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# This feature is obsolete. It may still work in some
-# browsers, but could stop working at any time. Try to
-# avoid using this component.
-#
-# Instead, use CSS properties to set font, font-family,
-# font-size and color.
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  # This feature is obsolete. It may still work in some
+  # browsers, but could stop working at any time. Try to
+  # avoid using this component.
+  #
+  # Instead, use CSS properties to set font, font-family,
+  # font-size and color.
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlBasefont(color="FF0000",
-                 face="Helvetica",
-                 size="+2"),
-    htmlP(children="If it works, this will be Helvetica but a couple point sizes larger.")
+  app$layout(
+    htmlDiv(list(
+      htmlBasefont(color="FF0000",
+                  face="Helvetica",
+                  size="+2"),
+      htmlP(children="If it works, this will be Helvetica but a couple point sizes larger.")
+      )
     )
-   )
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlBdi.Rd
+++ b/man/htmlBdi.Rd
@@ -10,10 +10,12 @@ Bdi is a wrapper for the <bdi> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlBdi(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlBdi(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-    htmlDiv(list(
-        htmlP(children="The line below should render as 'Aladdin', but in Arabic script:"),
-        htmlBdi(children="\U{0639}\U{0644}\U{0627}\U{0621} \U{0627}\U{0644}\U{062F}\U{064A}\U{0646}")
-    )
-    )
-)
+  app$layout(
+      htmlDiv(list(
+          htmlP(children="This text is 'Aladdin', but in Arabic script:"),
+          htmlBdi(children=paste0("\U{0639}\U{0644}\U{0627}\U{0621}",
+                                  "\U{0627}\U{0644}\U{062F}\U{064A}\U{0646}"))
+      )
+      )
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlBdo.Rd
+++ b/man/htmlBdo.Rd
@@ -10,10 +10,12 @@ Bdo is a wrapper for the <bdo> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlBdo(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlBdo(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,26 +67,34 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# This element supports bidirectional text override.
-# We can force text to render from right to left instead
-# of left to right.
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  # This element supports bidirectional text override.
+  # We can force text to render from right to left instead
+  # of left to right.
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP(children="This text will print from left to right."),
-    htmlP(children="Below, we use bidirectional override to print right to left:"),
-    htmlBdo(children="This text will print from right to left.",
-            dir="rtl")
-   )
+  app$layout(
+    htmlDiv(list(
+      htmlP(children="This text will print from left to right."),
+      htmlP(children="Below, we use bidirectional override to print right to left:"),
+      htmlBdo(children="This text will print from right to left.",
+              dir="rtl")
+    )
+    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlBig.Rd
+++ b/man/htmlBig.Rd
@@ -10,10 +10,12 @@ Big is a wrapper for the <big> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlBig(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlBig(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# The <big> tag is not supported in HTML5.
-# Instead, use the font-size property in
-# CSS to enlarge text.
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  # The <big> tag is not supported in HTML5.
+  # Instead, use the font-size property in
+  # CSS to enlarge text.
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP(children="This text will display in standard size."),
-    htmlBig(children="This text may or may not appear slightly larger.")
-   )
+  app$layout(
+    htmlDiv(list(
+      htmlP(children="This text will display in standard size."),
+      htmlBig(children="This text may or may not appear slightly larger.")
+    )
+    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlBlink.Rd
+++ b/man/htmlBlink.Rd
@@ -10,10 +10,12 @@ Blink is a wrapper for the <blink> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlBlink(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlBlink(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,27 +67,35 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# The blink tag is now obsolete and deprecated.
-# It may not function properly in all browsers,
-# and it may cease working without warning.
-#
-# This element is generally unsupported on all
-# modern browser releases.
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  # The blink tag is now obsolete and deprecated.
+  # It may not function properly in all browsers,
+  # and it may cease working without warning.
+  #
+  # This element is generally unsupported on all
+  # modern browser releases.
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP(children="Here is a bit of text."),
-    htmlBlink(children="Here is a bit of blinking text.")
-   )
+  app$layout(
+    htmlDiv(list(
+      htmlP(children="Here is a bit of text."),
+      htmlBlink(children="Here is a bit of blinking text.")
+    )
+    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlBlockquote.Rd
+++ b/man/htmlBlockquote.Rd
@@ -10,10 +10,12 @@ Blockquote is a wrapper for the <blockquote> HTML5 element. For detailed attribu
 }
 
 \usage{
-htmlBlockquote(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, cite=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlBlockquote(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, cite=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -67,24 +69,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {      
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP("Here is some text."),
-    htmlBlockquote(children=list(
-       htmlP("And here is a quotation in block format.")
-       )
+  app$layout(
+    htmlDiv(list(
+      htmlP("Here is some text."),
+      htmlBlockquote(children=list(
+        htmlP("And here is a quotation in block format.")
+        )
+      )
     )
-   )
+    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlBr.Rd
+++ b/man/htmlBr.Rd
@@ -10,10 +10,12 @@ Br is a wrapper for the <br> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlBr(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlBr(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP("Here is some text."),
-    htmlBr(),
-    htmlP("Here is additional text."),
-    htmlBr(),
-    htmlP("See the gap in between the lines?")
+  app$layout(
+    htmlDiv(list(
+      htmlP("Here is some text."),
+      htmlBr(),
+      htmlP("Here is additional text."),
+      htmlBr(),
+      htmlP("See the gap in between the lines?")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlButton.Rd
+++ b/man/htmlButton.Rd
@@ -10,13 +10,15 @@ Button is a wrapper for the <button> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlButton(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, autoFocus=NULL, disabled=NULL, form=NULL, formAction=NULL,
-formEncType=NULL, formMethod=NULL, formNoValidate=NULL, formTarget=NULL,
-name=NULL, type=NULL, value=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlButton(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+autoFocus=NULL, disabled=NULL, form=NULL, formAction=NULL,
+formEncType=NULL, formMethod=NULL, formNoValidate=NULL,
+formTarget=NULL, name=NULL, type=NULL, value=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -90,20 +92,28 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlButton("Click me!")
+  app$layout(
+    htmlDiv(list(
+      htmlButton("Click me!")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlCanvas.Rd
+++ b/man/htmlCanvas.Rd
@@ -10,11 +10,13 @@ Canvas is a wrapper for the <canvas> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlCanvas(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, height=NULL, width=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlCanvas(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, height=NULL,
+width=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -70,21 +72,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# this component requires JavaScript code to draw on the canvas
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  # this component requires JavaScript code to draw on the canvas
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlCanvas(id="canvas-component")
+  app$layout(
+    htmlDiv(list(
+      htmlCanvas(id="canvas-component")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlCaption.Rd
+++ b/man/htmlCaption.Rd
@@ -10,10 +10,12 @@ Caption is a wrapper for the <caption> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlCaption(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlCaption(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,59 +67,67 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlTable(list(
-      htmlCaption("Elevations of a few Cascade Range volcanoes"),
-      htmlThead(
-        htmlTr(list(
-          htmlTh("Mountain"),
-          htmlTh("Elevation (m)"),
-          htmlTh("Elevation (ft)")
+  app$layout(
+    htmlDiv(list(
+      htmlTable(list(
+        htmlCaption("Elevations of a few Cascade Range volcanoes"),
+        htmlThead(
+          htmlTr(list(
+            htmlTh("Mountain"),
+            htmlTh("Elevation (m)"),
+            htmlTh("Elevation (ft)")
+          )
+        )),
+        htmlTbody(list(
+          htmlTr(list(
+            htmlTd("Mount Rainier"),
+            htmlTd("4,392"),
+            htmlTd("14,411")
+          )
+          ),
+          htmlTr(list(
+            htmlTd("Mount Hood"),
+            htmlTd("3,429"),
+            htmlTd("11,249")
+          )
+          ),
+          htmlTr(list(
+            htmlTd("Lassen Peak"),
+            htmlTd("3,187"),
+            htmlTd("10,457")
+          )
+          ),
+          htmlTr(list(
+            htmlTd("Mount St. Helens"),
+            htmlTd("2,549"),
+            htmlTd("8,363")
+          )
+          )
         )
-      )),
-      htmlTbody(list(
-        htmlTr(list(
-          htmlTd("Mount Rainier"),
-          htmlTd("4,392"),
-          htmlTd("14,411")
-         )
-        ),
-        htmlTr(list(
-          htmlTd("Mount Hood"),
-          htmlTd("3,429"),
-          htmlTd("11,249")
         )
-        ),
-        htmlTr(list(
-          htmlTd("Lassen Peak"),
-          htmlTd("3,187"),
-          htmlTd("10,457")
-         )
-        ),
-        htmlTr(list(
-          htmlTd("Mount St. Helens"),
-          htmlTd("2,549"),
-          htmlTd("8,363")
-         )
-        )
-       )
+      ), style = list(
+            border = "1px black solid"
       )
-     ), style = list(
-          border = "1px black solid"
-     )
+      )
     )
   )
- )
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlCenter.Rd
+++ b/man/htmlCenter.Rd
@@ -10,10 +10,12 @@ Center is a wrapper for the <center> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlCenter(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlCenter(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,20 +67,28 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlCenter("Centered text!")
+  app$layout(
+    htmlDiv(list(
+      htmlCenter("Centered text!")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlCite.Rd
+++ b/man/htmlCite.Rd
@@ -10,10 +10,12 @@ Cite is a wrapper for the <cite> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlCite(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlCite(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,20 +67,28 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlCite("Click me!")
+  app$layout(
+    htmlDiv(list(
+      htmlCite("Click me!")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlCode.Rd
+++ b/man/htmlCode.Rd
@@ -10,10 +10,12 @@ Code is a wrapper for the <code> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlCode(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlCode(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlCode(
-    children = 'cat("Hello world!")'
+  app$layout(htmlDiv(list(
+    htmlCode(
+      children = 'cat("Hello world!")'
+        )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlCol.Rd
+++ b/man/htmlCol.Rd
@@ -10,10 +10,12 @@ Col is a wrapper for the <col> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlCol(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, span=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlCol(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, span=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -67,34 +69,42 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# Used within htmlColgroup to define columns.
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  # Used within htmlColgroup to define columns.
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlTable(list(
-        htmlColgroup(
-          list(
-            htmlCol(span = 2, style = list("background-color"= "red"))
+  app$layout(
+    htmlDiv(list(
+      htmlTable(list(
+          htmlColgroup(
+            list(
+              htmlCol(span = 2, style = list("background-color"= "red"))
+            )
+          ),
+          htmlTr(
+            list(
+              htmlTd("Cell A"),
+              htmlTd("Cell B"),
+              htmlTd("Cell C")
+            )
           )
-        ),
-        htmlTr(
-          list(
-            htmlTd("Cell A"),
-            htmlTd("Cell B"),
-            htmlTd("Cell C")
-          )
-        )
-      ))
+        ))
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlColgroup.Rd
+++ b/man/htmlColgroup.Rd
@@ -10,10 +10,12 @@ Colgroup is a wrapper for the <colgroup> HTML5 element. For detailed attribute i
 }
 
 \usage{
-htmlColgroup(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, span=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlColgroup(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, span=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -67,33 +69,41 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlTable(list(
-        htmlColgroup(
-          list(
-            htmlCol(span = 2, style = list("background-color"= "red"))
+  app$layout(
+    htmlDiv(list(
+      htmlTable(list(
+          htmlColgroup(
+            list(
+              htmlCol(span = 2, style = list("background-color"= "red"))
+            )
+          ),
+          htmlTr(
+            list(
+              htmlTd("Cell A"),
+              htmlTd("Cell B"),
+              htmlTd("Cell C")
+            )
           )
-        ),
-        htmlTr(
-          list(
-            htmlTd("Cell A"),
-            htmlTd("Cell B"),
-            htmlTd("Cell C")
-          )
-        )
-      ))
+        ))
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlCommand.Rd
+++ b/man/htmlCommand.Rd
@@ -10,11 +10,13 @@ Command is a wrapper for the <command> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlCommand(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, checked=NULL, disabled=NULL, icon=NULL, radioGroup=NULL, type=NULL,
-accessKey=NULL, className=NULL, contentEditable=NULL, contextMenu=NULL,
-dir=NULL, draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlCommand(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, checked=NULL,
+disabled=NULL, icon=NULL, radioGroup=NULL, type=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -76,8 +78,14 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # This component is deprecated and its use is no longer recommended.
-}}
+}

--- a/man/htmlContent.Rd
+++ b/man/htmlContent.Rd
@@ -10,10 +10,12 @@ Content is a wrapper for the <content> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlContent(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlContent(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,9 +67,15 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # This feature is obsolete and no longer supported. It is recommended
 # that you use the htmlSlot component instead.
-}}
+}

--- a/man/htmlData.Rd
+++ b/man/htmlData.Rd
@@ -10,10 +10,12 @@ Data is a wrapper for the <data> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlData(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, value=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlData(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, value=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -67,32 +69,40 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlUl(list(
-        htmlLi(list(htmlData(value = 398, "First Element"))),
-        htmlLi(list(htmlData(value = 399, "Second Element"))),
-        htmlLi(list(htmlData(value = 400, "First Element")))
-      ))
+  app$layout(
+    htmlDiv(list(
+      htmlUl(list(
+          htmlLi(list(htmlData(value = 398, "First Element"))),
+          htmlLi(list(htmlData(value = 399, "Second Element"))),
+          htmlLi(list(htmlData(value = 400, "First Element")))
+        ))
+      )
     )
   )
-)
 
-# Include the following in a seperate CSS file in an
-# `assets` directory in the root of your app.
-#
-# data:hover::after {
-#   content: ' (ID ' attr(value) ')';
-#   font-size: .7em;
-# }
+  # Include the following in a seperate CSS file in an
+  # `assets` directory in the root of your app.
+  #
+  # data:hover::after {
+  #   content: ' (ID ' attr(value) ')';
+  #   font-size: .7em;
+  # }
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlDatalist.Rd
+++ b/man/htmlDatalist.Rd
@@ -10,10 +10,12 @@ Datalist is a wrapper for the <datalist> HTML5 element. For detailed attribute i
 }
 
 \usage{
-htmlDatalist(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlDatalist(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,29 +67,37 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
-library(dashCoreComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
+  library(dashCoreComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  dccInput(
-    placeholder = 'Enter here',
-    list = 'list-of-options'),
-  htmlDatalist(id = 'list-of-options',
-    children=list(
-      htmlOption("Option 1"),
-      htmlOption("Option 2"),
-      htmlOption("Option 3")
+  app$layout(htmlDiv(list(
+    dccInput(
+      placeholder = 'Enter here',
+      list = 'list-of-options'),
+    htmlDatalist(id = 'list-of-options',
+      children=list(
+        htmlOption("Option 1"),
+        htmlOption("Option 2"),
+        htmlOption("Option 3")
+          )
         )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlDd.Rd
+++ b/man/htmlDd.Rd
@@ -10,10 +10,12 @@ Dd is a wrapper for the <dd> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlDd(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlDd(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,23 +67,31 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlDl(
-    children= list(htmlDt("Dash for R"),
-                  htmlDd('HtmlDt and htmlDD must be used
-                          within htmlDl'))
+  app$layout(htmlDiv(list(
+    htmlDl(
+      children= list(htmlDt("Dash for R"),
+                    htmlDd('HtmlDt and htmlDD must be used
+                            within htmlDl'))
+        )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlDel.Rd
+++ b/man/htmlDel.Rd
@@ -10,11 +10,13 @@ Del is a wrapper for the <del> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlDel(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, cite=NULL, dateTime=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlDel(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, cite=NULL,
+dateTime=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -70,21 +72,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlDel(
-        children ="Deleted Hello"
+  app$layout(htmlDiv(list(
+    htmlDel(
+          children ="Deleted Hello"
+        )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlDetails.Rd
+++ b/man/htmlDetails.Rd
@@ -10,10 +10,12 @@ Details is a wrapper for the <details> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlDetails(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, open=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlDetails(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, open=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -67,27 +69,35 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlDetails(
-      children = list(
-        htmlSummary(
-          children = "Within a details element, the summary can act as a clickable description"
-        ),
-        "And the rest is hidden until the summary is clicked"
+  app$layout(
+    htmlDiv(list(
+      htmlDetails(
+        children = list(
+          htmlSummary(
+            children = "Within a details element, the summary can act as a clickable description"
+          ),
+          "And the rest is hidden until the summary is clicked"
+        )
+      )
       )
     )
-    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlDfn.Rd
+++ b/man/htmlDfn.Rd
@@ -10,10 +10,12 @@ Dfn is a wrapper for the <dfn> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlDfn(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlDfn(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlDfn(
-        children ="Hello"
+  app$layout(htmlDiv(list(
+    htmlDfn(
+          children ="Hello"
+        )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlDialog.Rd
+++ b/man/htmlDialog.Rd
@@ -10,10 +10,12 @@ Dialog is a wrapper for the <dialog> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlDialog(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlDialog(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlDialog(
-    children = htmlP('Greetings')
+  app$layout(htmlDiv(list(
+    htmlDialog(
+      children = htmlP('Greetings')
+        )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlDiv.Rd
+++ b/man/htmlDiv.Rd
@@ -10,10 +10,12 @@ Div is a wrapper for the <div> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlDiv(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlDiv(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,17 +67,28 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
-}
-\examples{
-\dontrun{
-app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlDiv('This Title is Wrapped inside an inner Div')
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
+}
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
+\examples{
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
+  
+  app <- Dash$new()
+
+  app$layout(
+    htmlDiv(list(
+      htmlDiv('This Title is Wrapped inside an inner Div')
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlDl.Rd
+++ b/man/htmlDl.Rd
@@ -10,10 +10,12 @@ Dl is a wrapper for the <dl> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlDl(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlDl(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,23 +67,31 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlDl(
-    children= list(htmlDt("Dash for R"),
-                  htmlDd('HtmlDt and htmlDD must be used
-                          within htmlDl'))
+  app$layout(htmlDiv(list(
+    htmlDl(
+      children= list(htmlDt("Dash for R"),
+                    htmlDd('HtmlDt and htmlDD must be used
+                            within htmlDl'))
+        )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlDt.Rd
+++ b/man/htmlDt.Rd
@@ -10,10 +10,12 @@ Dt is a wrapper for the <dt> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlDt(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlDt(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,23 +67,31 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlDl(
-    children= list(htmlDt("Dash for R"),
-                  htmlDd('HtmlDt and htmlDD must be used
-                          within htmlDl'))
+  app$layout(htmlDiv(list(
+    htmlDl(
+      children= list(htmlDt("Dash for R"),
+                    htmlDd('HtmlDt and htmlDD must be used
+                            within htmlDl'))
+        )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlElement.Rd
+++ b/man/htmlElement.Rd
@@ -10,10 +10,12 @@ Element is a wrapper for the <element> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlElement(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlElement(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,10 +67,16 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # This feature is obsolete. It may still work in some
 # browsers, but could stop working at any time. Try to
 # avoid using this component.
-}}
+}

--- a/man/htmlEm.Rd
+++ b/man/htmlEm.Rd
@@ -10,10 +10,12 @@ Em is a wrapper for the <em> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlEm(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlEm(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,22 +67,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlH1(list('Dash is a very ',
-              htmlEm(' important '),
-              'framework')
+  app$layout(htmlDiv(list(
+    htmlH1(list('Dash is a very ',
+                htmlEm(' important '),
+                'framework')
+        )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlEmbed.Rd
+++ b/man/htmlEmbed.Rd
@@ -10,11 +10,13 @@ Embed is a wrapper for the <embed> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlEmbed(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, height=NULL, src=NULL, type=NULL, width=NULL, accessKey=NULL,
-className=NULL, contentEditable=NULL, contextMenu=NULL, dir=NULL,
-draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlEmbed(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, height=NULL,
+src=NULL, type=NULL, width=NULL, accessKey=NULL,
+className=NULL, contentEditable=NULL, contextMenu=NULL,
+dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
+spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
+loading_state=NULL, ...)
 }
 
 \arguments{
@@ -74,22 +76,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlEmbed(
-    src = 'https://archive.org/embed/VintageCartoonsSet1Mp4',
-    width = '500',
-    height = '500')
+  app$layout(htmlDiv(list(
+    htmlEmbed(
+      src = 'https://archive.org/embed/VintageCartoonsSet1Mp4',
+      width = '500',
+      height = '500')
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlFieldset.Rd
+++ b/man/htmlFieldset.Rd
@@ -10,11 +10,13 @@ Fieldset is a wrapper for the <fieldset> HTML5 element. For detailed attribute i
 }
 
 \usage{
-htmlFieldset(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, disabled=NULL, form=NULL, name=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlFieldset(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, disabled=NULL,
+form=NULL, name=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -72,30 +74,38 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
-library(dashCoreComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
+  library(dashCoreComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlFieldset(
-    children = list('Choose your favorite Dash HTML component',
-    dccRadioItems(
-      options=list(
-        list("label'= "htmlDiv", "value'= "htmlDiv"),
-        list("label'= "htmlBase", "value'= "htmlBase"),
-        list("label'= "htmlArticle", "value'= "htmlArticle")
+  app$layout(htmlDiv(list(
+    htmlFieldset(
+      children = list('Choose your favorite Dash HTML component',
+      dccRadioItems(
+        options=list(
+          list("label"= "htmlDiv", "value"= "htmlDiv"),
+          list("label"= "htmlBase", "value"= "htmlBase"),
+          list("label"= "htmlArticle", "value"= "htmlArticle")
+              )
             )
           )
         )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlFigcaption.Rd
+++ b/man/htmlFigcaption.Rd
@@ -10,10 +10,12 @@ Figcaption is a wrapper for the <figcaption> HTML5 element. For detailed attribu
 }
 
 \usage{
-htmlFigcaption(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlFigcaption(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlFigure(children = list(
-    htmlImg(src = 'https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png'),
-    htmlFigcaption(children = 'Plotly Logo')))
+  app$layout(htmlDiv(list(
+    htmlFigure(children = list(
+      htmlImg(src = 'https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png'),
+      htmlFigcaption(children = 'Plotly Logo')))
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlFigure.Rd
+++ b/man/htmlFigure.Rd
@@ -10,10 +10,12 @@ Figure is a wrapper for the <figure> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlFigure(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlFigure(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlFigure(children = list(
-    htmlImg(src = 'https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png',
-            width = '400',
-            height = '150')
+  app$layout(htmlDiv(list(
+    htmlFigure(children = list(
+      htmlImg(src = 'https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png',
+              width = '400',
+              height = '150')
+          )
         )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlFont.Rd
+++ b/man/htmlFont.Rd
@@ -10,10 +10,12 @@ Font is a wrapper for the <font> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlFont(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlFont(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,10 +67,16 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # Starting with HTML 4, HTML does not convey styling information
 # anymore (outside the <style> element or the style attribute of each
 # element). CSS should be used for styling instead.
-}}
+}

--- a/man/htmlFooter.Rd
+++ b/man/htmlFooter.Rd
@@ -10,10 +10,12 @@ Footer is a wrapper for the <footer> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlFooter(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlFooter(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlFooter(list(
-    htmlH1('Dash'),
-    htmlLi('Pointer1'),
-    htmlLi('Pointer2')
+  app$layout(htmlDiv(list(
+    htmlFooter(list(
+      htmlH1('Dash'),
+      htmlLi('Pointer1'),
+      htmlLi('Pointer2')
+          )
         )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlForm.Rd
+++ b/man/htmlForm.Rd
@@ -10,12 +10,15 @@ Form is a wrapper for the <form> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlForm(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accept=NULL, acceptCharset=NULL, action=NULL, autoComplete=NULL,
-encType=NULL, method=NULL, name=NULL, noValidate=NULL, target=NULL,
-accessKey=NULL, className=NULL, contentEditable=NULL, contextMenu=NULL,
-dir=NULL, draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlForm(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, accept=NULL,
+acceptCharset=NULL, action=NULL, autoComplete=NULL,
+encType=NULL, method=NULL, name=NULL, noValidate=NULL,
+target=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -85,25 +88,41 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
-library(dashCoreComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
+  library(dashCoreComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlForm(children=list(
-    htmlP(children=list('Username: ', dccInput(type='text', id='username', placeholder='username'))),
-    htmlP(children=list('Password: ', dccInput(type='password', id='password', placeholder='password'))),
-    htmlButton(children=list('Login'), type='submit', id='login_button')
+  app$layout(htmlDiv(list(
+    htmlForm(children=list(
+      htmlP(children=list('Username: ',
+                          dccInput(type='text', 
+                                   id='username', 
+                                   placeholder='username'))),
+      htmlP(children=list('Password: ',
+                          dccInput(type='password', 
+                                   id='password',
+                                   placeholder='password'))),
+      htmlButton(children=list('Login'), 
+                 type='submit', 
+                 id='login_button')
+          )
         )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()              
+}
+}

--- a/man/htmlFrame.Rd
+++ b/man/htmlFrame.Rd
@@ -10,10 +10,12 @@ Frame is a wrapper for the <frame> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlFrame(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlFrame(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,8 +67,14 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # htmlFrame is now deprecated. htmlIFrame is recommended instead.
-}}
+}

--- a/man/htmlFrameset.Rd
+++ b/man/htmlFrameset.Rd
@@ -10,10 +10,12 @@ Frameset is a wrapper for the <frameset> HTML5 element. For detailed attribute i
 }
 
 \usage{
-htmlFrameset(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlFrameset(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,8 +67,14 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # htmlFrameset is now deprecated. htmlIFrame is recommended instead.
-}}
+}

--- a/man/htmlH1.Rd
+++ b/man/htmlH1.Rd
@@ -10,10 +10,12 @@ H1 is a wrapper for the <h1> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlH1(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlH1(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {      
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlH1(list(
-      'Dash Html',
-      htmlBr(), #We can customize
-      htmlSpan('Dash', style = list('opacity' = '0.8')),
-      htmlSpan(' Core')))
+  app$layout(
+    htmlDiv(list(
+      htmlH1(list(
+        'Dash Html',
+        htmlBr(), #We can customize
+        htmlSpan('Dash', style = list('opacity' = '0.8')),
+        htmlSpan(' Core')))
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlH2.Rd
+++ b/man/htmlH2.Rd
@@ -10,10 +10,12 @@ H2 is a wrapper for the <h2> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlH2(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlH2(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlH2(list(
-      'Dash Html',
-      htmlBr(), #We can customize
-      htmlSpan('Dash', style = list('opacity' = '0.8')),
-      htmlSpan(' Core')))
+  app$layout(
+    htmlDiv(list(
+      htmlH2(list(
+        'Dash Html',
+        htmlBr(), #We can customize
+        htmlSpan('Dash', style = list('opacity' = '0.8')),
+        htmlSpan(' Core')))
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlH3.Rd
+++ b/man/htmlH3.Rd
@@ -10,10 +10,12 @@ H3 is a wrapper for the <h3> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlH3(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlH3(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlH3(list(
-      'Dash Html',
-      htmlBr(), #We can customize
-      htmlSpan('Dash', style = list('opacity' = '0.8')),
-      htmlSpan(' Core')))
+  app$layout(
+    htmlDiv(list(
+      htmlH3(list(
+        'Dash Html',
+        htmlBr(), #We can customize
+        htmlSpan('Dash', style = list('opacity' = '0.8')),
+        htmlSpan(' Core')))
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlH4.Rd
+++ b/man/htmlH4.Rd
@@ -10,10 +10,12 @@ H4 is a wrapper for the <h4> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlH4(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlH4(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlH4(list(
-      'Dash Html',
-      htmlBr(), #We can customize
-      htmlSpan('Dash', style = list('opacity' = '0.8')),
-      htmlSpan(' Core')))
+  app$layout(
+    htmlDiv(list(
+      htmlH4(list(
+        'Dash Html',
+        htmlBr(), #We can customize
+        htmlSpan('Dash', style = list('opacity' = '0.8')),
+        htmlSpan(' Core')))
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlH5.Rd
+++ b/man/htmlH5.Rd
@@ -10,10 +10,12 @@ H5 is a wrapper for the <h5> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlH5(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlH5(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlH5(list(
-      'Dash Html',
-      htmlBr(), #We can customize
-      htmlSpan('Dash', style = list('opacity' = '0.8')),
-      htmlSpan(' Core')))
+  app$layout(
+    htmlDiv(list(
+      htmlH5(list(
+        'Dash Html',
+        htmlBr(), #We can customize
+        htmlSpan('Dash', style = list('opacity' = '0.8')),
+        htmlSpan(' Core')))
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlH6.Rd
+++ b/man/htmlH6.Rd
@@ -10,10 +10,12 @@ H6 is a wrapper for the <h6> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlH6(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlH6(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlH6(list(
-      'Dash Html',
-      htmlBr(), #We can customize
-      htmlSpan('Dash', style = list('opacity' = '0.8')),
-      htmlSpan(' Core')))
+  app$layout(
+    htmlDiv(list(
+      htmlH6(list(
+        'Dash Html',
+        htmlBr(), #We can customize
+        htmlSpan('Dash', style = list('opacity' = '0.8')),
+        htmlSpan(' Core')))
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlHeader.Rd
+++ b/man/htmlHeader.Rd
@@ -10,10 +10,12 @@ Header is a wrapper for the <header> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlHeader(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlHeader(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlHeader("This is a header"),
-    htmlP("And here is some text.")
+  app$layout(
+    htmlDiv(list(
+      htmlHeader("This is a header"),
+      htmlP("And here is some text.")
+    )
   )
- )
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlHgroup.Rd
+++ b/man/htmlHgroup.Rd
@@ -10,10 +10,12 @@ Hgroup is a wrapper for the <hgroup> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlHgroup(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlHgroup(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,25 +67,33 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlHgroup(list(
-      htmlH1('MultiLevel Title'),
-      htmlHr(),
-      htmlH2('Header')
+  app$layout(
+    htmlDiv(list(
+      htmlHgroup(list(
+        htmlH1('MultiLevel Title'),
+        htmlHr(),
+        htmlH2('Header')
+          )
         )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlHr.Rd
+++ b/man/htmlHr.Rd
@@ -10,10 +10,12 @@ Hr is a wrapper for the <hr> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlHr(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlHr(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,25 +67,33 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
+  app$layout(
     htmlDiv(list(
-      htmlH1('Dash'),
-      htmlHr(),
-      htmlH2('Components')
+      htmlDiv(list(
+        htmlH1('Dash'),
+        htmlHr(),
+        htmlH2('Components')
+          )
         )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlI.Rd
+++ b/man/htmlI.Rd
@@ -10,10 +10,12 @@ I is a wrapper for the <i> HTML5 element. For detailed attribute info see: https
 }
 
 \usage{
-htmlI(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlI(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,20 +67,28 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-      htmlI('Italicized Text')
+  app$layout(
+    htmlDiv(list(
+        htmlI('Italicized Text')
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlIframe.Rd
+++ b/man/htmlIframe.Rd
@@ -10,11 +10,13 @@ Iframe is a wrapper for the <iframe> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlIframe(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, height=NULL, name=NULL, sandbox=NULL, src=NULL, srcDoc=NULL,
-width=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlIframe(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, height=NULL,
+name=NULL, sandbox=NULL, src=NULL, srcDoc=NULL, width=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -78,20 +80,28 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlIframe(width = "600px", height = "600px",
-            src = "https://dashr.plotly.com/")
+  app$layout(htmlDiv(list(
+    htmlIframe(width = "600px", height = "600px",
+              src = "https://dashr.plotly.com/")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlImg.Rd
+++ b/man/htmlImg.Rd
@@ -10,12 +10,14 @@ Img is a wrapper for the <img> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlImg(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, alt=NULL, crossOrigin=NULL, height=NULL, sizes=NULL, src=NULL,
-srcSet=NULL, useMap=NULL, width=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlImg(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, alt=NULL,
+crossOrigin=NULL, height=NULL, sizes=NULL, src=NULL,
+srcSet=NULL, useMap=NULL, width=NULL, accessKey=NULL,
+className=NULL, contentEditable=NULL, contextMenu=NULL,
+dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
+spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
+loading_state=NULL, ...)
 }
 
 \arguments{
@@ -83,21 +85,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-    htmlImg(src ='https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png',
-            height='200', width='400')
+  app$layout(htmlDiv(list(
+      htmlImg(src ='https://brand.plotly.com/static/images/plotly-logo-01-stripe@2x.png',
+              height='200', width='400')
+      )
     )
   )
-)
 
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlIns.Rd
+++ b/man/htmlIns.Rd
@@ -10,11 +10,13 @@ Ins is a wrapper for the <ins> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlIns(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, cite=NULL, dateTime=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlIns(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, cite=NULL,
+dateTime=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -70,20 +72,28 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlIns('This text has been inserted')
+  app$layout(
+    htmlDiv(list(
+      htmlIns('This text has been inserted')
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlIsindex.Rd
+++ b/man/htmlIsindex.Rd
@@ -10,10 +10,12 @@ Isindex is a wrapper for the <isindex> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlIsindex(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlIsindex(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,8 +67,14 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # This component is deprecated and its use is no longer recommended.
-}}
+}

--- a/man/htmlKbd.Rd
+++ b/man/htmlKbd.Rd
@@ -10,10 +10,12 @@ Kbd is a wrapper for the <kbd> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlKbd(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlKbd(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP('Please Press: '),
-    htmlKbd(list(
-      'Ctl + ',
-      'Alt + ',
-      'Delete'))
+  app$layout(
+    htmlDiv(list(
+      htmlP('Please Press: '),
+      htmlKbd(list(
+        'Ctl + ',
+        'Alt + ',
+        'Delete'))
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlKeygen.Rd
+++ b/man/htmlKeygen.Rd
@@ -10,11 +10,14 @@ Keygen is a wrapper for the <keygen> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlKeygen(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, autoFocus=NULL, challenge=NULL, disabled=NULL, form=NULL,
-keyType=NULL, name=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlKeygen(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+autoFocus=NULL, challenge=NULL, disabled=NULL, form=NULL,
+keyType=NULL, name=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -78,10 +81,16 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # This feature is obsolete. It may still work in some
 # browsers, but could stop working at any time. Try to
 # avoid using this component.
-}}
+}

--- a/man/htmlLabel.Rd
+++ b/man/htmlLabel.Rd
@@ -10,11 +10,13 @@ Label is a wrapper for the <label> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlLabel(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, htmlFor=NULL, form=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlLabel(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, htmlFor=NULL,
+form=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -70,30 +72,38 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
-library(dashCoreComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
+  library(dashCoreComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(
-    htmlLabel(
-      list(htmlDiv(list("Time points")),
-          dccInput(
-            id = "times-input",
-            placeholder = "Enter a value...",
-            type = "number",
-            value = 1,
-            min = 3,
-            max = 999)
+  app$layout(
+    htmlDiv(
+      htmlLabel(
+        list(htmlDiv(list("Time points")),
+            dccInput(
+              id = "times-input",
+              placeholder = "Enter a value...",
+              type = "number",
+              value = 1,
+              min = 3,
+              max = 999)
+        )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlLegend.Rd
+++ b/man/htmlLegend.Rd
@@ -10,10 +10,12 @@ Legend is a wrapper for the <legend> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlLegend(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlLegend(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,31 +67,39 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
-library(dashCoreComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
+  library(dashCoreComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(htmlDiv(list(
-  htmlFieldset(
-    children = list(
-                    htmlLegend('Select your favorite component'),
-                    dccRadioItems(
-                      options=list(
-                        list("label'= "htmlDiv", "value'= "htmlDiv"),
-                        list("label'= "htmlBase", "value'= "htmlBase"),
-                        list("label'= "htmlArticle", "value'= "htmlArticle")
+  app$layout(htmlDiv(list(
+    htmlFieldset(
+      children = list(
+                      htmlLegend('Select your favorite component'),
+                      dccRadioItems(
+                        options=list(
+                          list("label"= "htmlDiv", "value"= "htmlDiv"),
+                          list("label"= "htmlBase", "value"= "htmlBase"),
+                          list("label"= "htmlArticle", "value"= "htmlArticle")
+              )
             )
           )
         )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlLi.Rd
+++ b/man/htmlLi.Rd
@@ -10,10 +10,12 @@ Li is a wrapper for the <li> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlLi(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, value=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlLi(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, value=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -67,28 +69,36 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlOl(list(
-      htmlLi("Montreal"),
-      htmlLi("Toronto"),
-      htmlLi("Halifax")
-    )),
-    htmlUl(list(
-      htmlLi("Montreal"),
-      htmlLi("Toronto"),
-      htmlLi("Halifax")
+  app$layout(
+    htmlDiv(list(
+      htmlOl(list(
+        htmlLi("Montreal"),
+        htmlLi("Toronto"),
+        htmlLi("Halifax")
+      )),
+      htmlUl(list(
+        htmlLi("Montreal"),
+        htmlLi("Toronto"),
+        htmlLi("Halifax")
+      ))
     ))
-  ))
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlLink.Rd
+++ b/man/htmlLink.Rd
@@ -10,12 +10,14 @@ Link is a wrapper for the <link> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlLink(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, crossOrigin=NULL, href=NULL, hrefLang=NULL, integrity=NULL,
-media=NULL, rel=NULL, sizes=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlLink(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+crossOrigin=NULL, href=NULL, hrefLang=NULL, integrity=NULL,
+media=NULL, rel=NULL, sizes=NULL, accessKey=NULL,
+className=NULL, contentEditable=NULL, contextMenu=NULL,
+dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
+spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
+loading_state=NULL, ...)
 }
 
 \arguments{
@@ -81,19 +83,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlLink(rel = "stylesheet", type = "text/css", href = "https://codepen.io/chriddyp/pen/bWLwgP.css")
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlLink(rel = "stylesheet",
+              type = "text/css",
+              href = "https://codepen.io/chriddyp/pen/bWLwgP.css")
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlListing.Rd
+++ b/man/htmlListing.Rd
@@ -10,10 +10,12 @@ Listing is a wrapper for the <listing> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlListing(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlListing(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,28 +67,36 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# Warning: The <listing> element was intended as a way to render HTML code on a page.
-# It was never properly supported, and is now deprecated. Using <listing> will almost
-# certainly result in unexpected results. Instead, use <code>, or place the content in
-# a <div> with the appropriate CSS styling.
+if (interactive() && require(dash)) {
+  # Warning: The <listing> element was intended as a way to render HTML code on a page.
+  # It was never properly supported, and is now deprecated. Using <listing> will almost
+  # certainly result in unexpected results. Instead, use <code>, or place the content in
+  # a <div> with the appropriate CSS styling.
 
-library(dash)
-library(dashHtmlComponents)
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlListing(list(
-      htmlUl("A"),
-      htmlUl("B"),
-      htmlUl("C")
+  app$layout(
+    htmlDiv(list(
+      htmlListing(list(
+        htmlUl("A"),
+        htmlUl("B"),
+        htmlUl("C")
+      ))
     ))
-  ))
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlMain.Rd
+++ b/man/htmlMain.Rd
@@ -10,10 +10,12 @@ Main is a wrapper for the <main> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlMain(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlMain(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,26 +67,34 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlMain(
-      list(htmlH1("Benjamin Franklin"),
-           htmlP("Benjamin Franklin was an American polymath
-                 and one of the Founding Fathers of the United States.
-                 Franklin was a leading author, printer, political theorist,
-                 politician, Freemason, postmaster, scientist, inventor,
-                 humorist, civic activist, statesman, and diplomat."))
-    )
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlMain(
+        list(htmlH1("Benjamin Franklin"),
+            htmlP("Benjamin Franklin was an American polymath
+                  and one of the Founding Fathers of the United States.
+                  Franklin was a leading author, printer, political theorist,
+                  politician, Freemason, postmaster, scientist, inventor,
+                  humorist, civic activist, statesman, and diplomat."))
+      )
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlMapEl.Rd
+++ b/man/htmlMapEl.Rd
@@ -10,10 +10,12 @@ MapEl is a wrapper for the <map> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlMapEl(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, name=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlMapEl(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, name=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -67,47 +69,54 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# Note that htmlMapEl generates the <map> HTML element;
-# for more information, please visit the link in this
-# component's description.
-library(dash)
-library(dashHtmlComponents)
-
-app <- Dash$new()
-
-app$layout(
-  htmlDiv(list(
-    htmlImg(src = "https://upload.wikimedia.org/wikipedia/commons/0/0c/PIA17351-ApparentSizes-MarsDeimosPhobos-EarthMoon.jpg",
-            useMap = "#image-map"),
-    htmlMapEl(list(
-      htmlArea(target="_blank",
-               alt="Deimos",
-               title="Deimos",
-               href="https://en.wikipedia.org/wiki/Deimos_(moon)",
-               coords="5,114,32,147",
-               shape="rect"),
-      htmlArea(target="_blank",
-               alt="Phobos",
-               title="Phobos",
-               href="https://en.wikipedia.org/wiki/Phobos_(moon)",
-               coords="113,196,32,103",
-               shape="rect"),
-      htmlArea(target="_blank",
-               alt="Moon",
-               title="Moon",
-               href="https://en.wikipedia.org/wiki/Moon",
-               coords="127,285,294,1",
-               shape="rect")
+# The URL below has been chunked to comply with CRAN
+# requirements; the use of file.path is optional and not required
+# for this component.
+if (interactive() && require(dash)) {
+  app$layout(
+    htmlDiv(list(
+      htmlImg(src = file.path('https://upload.wikimedia.org',
+              'wikipedia/commons/0/0c',
+              'PIA17351-ApparentSizes-MarsDeimosPhobos-EarthMoon.jpg',
+              fsep = '/'),
+              useMap = '#image-map'),
+      htmlMapEl(list(
+        htmlArea(target='_blank',
+                alt='Deimos',
+                title='Deimos',
+                href='https://en.wikipedia.org/wiki/Deimos_(moon)',
+                coords='5,114,32,147',
+                shape='rect'),
+        htmlArea(target='_blank',
+                alt='Phobos',
+                title='Phobos',
+                href='https://en.wikipedia.org/wiki/Phobos_(moon)',
+                coords='113,196,32,103',
+                shape='rect'),
+        htmlArea(target='_blank',
+                alt='Moon',
+                title='Moon',
+                href='https://en.wikipedia.org/wiki/Moon',
+                coords='127,285,294,1',
+                shape='rect')
+        ),
+        name = 'image-map'
       ),
-      name = "image-map"
-    ),
-    htmlDiv(children = "Click on the image to visit a Wikipedia article",
-            id = "object-name")
+      htmlDiv(children = 'Click on the image to visit a Wikipedia article',
+              id = 'object-name')
+      )
     )
   )
-)
-app$run_server()
-}}
+
+  app$run_server()
+}
+}

--- a/man/htmlMark.Rd
+++ b/man/htmlMark.Rd
@@ -10,10 +10,12 @@ Mark is a wrapper for the <mark> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlMark(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlMark(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,22 +67,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP(list(
-      htmlMark("Plotly"),
-      " develops online data analytics and visualization tools."
+  app$layout(
+    htmlDiv(list(
+      htmlP(list(
+        htmlMark("Plotly"),
+        " develops online data analytics and visualization tools."
+      ))
     ))
-  ))
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlMarquee.Rd
+++ b/man/htmlMarquee.Rd
@@ -10,10 +10,12 @@ Marquee is a wrapper for the <marquee> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlMarquee(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, loop=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlMarquee(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, loop=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -67,24 +69,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# This feature is obsolete. It may still work in some
-# browsers, but could stop working at any time. Try to
-# avoid using this component.
+if (interactive() && require(dash)) {
+  # This feature is obsolete. It may still work in some
+  # browsers, but could stop working at any time. Try to
+  # avoid using this component.
 
-library(dash)
-library(dashHtmlComponents)
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlMarquee("Here is some sliding text that uses htmlMarquee")
+  app$layout(
+    htmlDiv(list(
+      htmlMarquee("Here is some sliding text that uses htmlMarquee")
 
-  ))
-)
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlMeta.Rd
+++ b/man/htmlMeta.Rd
@@ -10,11 +10,13 @@ Meta is a wrapper for the <meta> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlMeta(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, charSet=NULL, content=NULL, httpEquiv=NULL, name=NULL,
-accessKey=NULL, className=NULL, contentEditable=NULL, contextMenu=NULL,
-dir=NULL, draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlMeta(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, charSet=NULL,
+content=NULL, httpEquiv=NULL, name=NULL, accessKey=NULL,
+className=NULL, contentEditable=NULL, contextMenu=NULL,
+dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
+spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
+loading_state=NULL, ...)
 }
 
 \arguments{
@@ -74,22 +76,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP("The <meta> tag provides metadata about the HTML document.
-          Metadata will not be displayed on the page, but will be machine parsable.
-          To view meta tag the content of this page can be inspected."),
-    htmlMeta(name = "author", content = "Edward Tufte")
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlP("The <meta> tag provides metadata about the HTML document.
+            Metadata will not be displayed on the page, but will be machine parsable.
+            To view meta tag the content of this page can be inspected."),
+      htmlMeta(name = "author", content = "Edward Tufte")
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlMeter.Rd
+++ b/man/htmlMeter.Rd
@@ -10,11 +10,14 @@ Meter is a wrapper for the <meter> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlMeter(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, form=NULL, high=NULL, low=NULL, max=NULL, min=NULL, optimum=NULL,
-value=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlMeter(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, form=NULL,
+high=NULL, low=NULL, max=NULL, min=NULL, optimum=NULL,
+value=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -80,27 +83,35 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlLabel("Sample Level Meter: "),
-    htmlMeter(id = "sample-meter",
-              min = 0,
-              max = 100,
-              low = 33,
-              high = 66,
-              optimum = 80,
-              value = 80
-              )
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlLabel("Sample Level Meter: "),
+      htmlMeter(id = "sample-meter",
+                min = 0,
+                max = 100,
+                low = 33,
+                high = 66,
+                optimum = 80,
+                value = 80
+                )
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlMulticol.Rd
+++ b/man/htmlMulticol.Rd
@@ -10,10 +10,12 @@ Multicol is a wrapper for the <multicol> HTML5 element. For detailed attribute i
 }
 
 \usage{
-htmlMulticol(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlMulticol(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,9 +67,15 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # Warning: The <multicol> tag is obsolete, it might not work as intended.
 # Try to avoid using it.
-}}
+}

--- a/man/htmlNav.Rd
+++ b/man/htmlNav.Rd
@@ -10,10 +10,12 @@ Nav is a wrapper for the <nav> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlNav(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlNav(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,27 +67,35 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlNav(
-      list(
-        htmlA("Plotly", href = "https://plotly.com/"),
-        '> ",
-        htmlA("Dash", href = "https://plotly.com/dash"),
-        '> ",
-        htmlA("Request Trial", href = "https://go.plotly.com/dash-enterprise-trial")
+  app$layout(
+    htmlDiv(list(
+      htmlNav(
+        list(
+          htmlA("Plotly", href = "https://plotly.com/"),
+          "> ",
+          htmlA("Dash", href = "https://plotly.com/dash"),
+          "> ",
+          htmlA("Request Trial", href = "https://go.plotly.com/dash-enterprise-trial")
+        )
       )
-    )
-  ))
-)
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlNextid.Rd
+++ b/man/htmlNextid.Rd
@@ -10,10 +10,12 @@ Nextid is a wrapper for the <nextid> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlNextid(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlNextid(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,9 +67,15 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # This component is deprecated and its use is no longer recommended.
 # The <nextid> tag has been obsolete since HTML Version 3.2.
-}}
+}

--- a/man/htmlNobr.Rd
+++ b/man/htmlNobr.Rd
@@ -10,10 +10,12 @@ Nobr is a wrapper for the <nobr> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlNobr(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlNobr(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,28 +67,36 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlNobr("Lorem ipsum dolor sit amet,
-             consectetur adipiscing elit, sed do eiusmod
-             tempor incididunt ut labore et dolore magna aliqua.
-             Ut enim ad minim veniam, quis nostrud exercitation
-             ullamco laboris nisi ut aliquip ex ea commodo consequat.
-             Duis aute irure dolor in reprehenderit in voluptate
-             velit esse cillum dolore eu fugiat nulla pariatur.
-             Excepteur sint occaecat cupidatat non proident,
-             sunt in culpa qui officia deserunt mollit anim id est laborum."
-    )
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlNobr("Lorem ipsum dolor sit amet,
+              consectetur adipiscing elit, sed do eiusmod
+              tempor incididunt ut labore et dolore magna aliqua.
+              Ut enim ad minim veniam, quis nostrud exercitation
+              ullamco laboris nisi ut aliquip ex ea commodo consequat.
+              Duis aute irure dolor in reprehenderit in voluptate
+              velit esse cillum dolore eu fugiat nulla pariatur.
+              Excepteur sint occaecat cupidatat non proident,
+              sunt in culpa qui officia deserunt mollit anim id est laborum."
+      )
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlNoscript.Rd
+++ b/man/htmlNoscript.Rd
@@ -10,10 +10,12 @@ Noscript is a wrapper for the <noscript> HTML5 element. For detailed attribute i
 }
 
 \usage{
-htmlNoscript(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlNoscript(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,10 +67,16 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # This component may be used in the index template to define
 # alternate content in browsers which have disabled scripts,
 # or in which scripts are not supported.
-}}
+}

--- a/man/htmlObjectEl.Rd
+++ b/man/htmlObjectEl.Rd
@@ -10,11 +10,13 @@ ObjectEl is a wrapper for the <object> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlObjectEl(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, form=NULL, height=NULL, name=NULL, type=NULL, useMap=NULL,
-width=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlObjectEl(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, form=NULL,
+height=NULL, name=NULL, type=NULL, useMap=NULL, width=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -78,26 +80,34 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# Note that htmlObjectEl generates the <object> HTML element;
-# for more information, please visit the link in this
-# component's description.
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  # Note that htmlObjectEl generates the <object> HTML element;
+  # for more information, please visit the link in this
+  # component's description.
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlObjectEl(
-      width = 100,
-      height = 97
-      #data = "https://i.postimg.cc/tJd8PSVf/Plotly-logo-01-square.png"
-    )
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlObjectEl(
+        width = 100,
+        height = 97
+        #data = "https://i.postimg.cc/tJd8PSVf/Plotly-logo-01-square.png"
+      )
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlOl.Rd
+++ b/man/htmlOl.Rd
@@ -10,11 +10,13 @@ Ol is a wrapper for the <ol> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlOl(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, reversed=NULL, start=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlOl(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, reversed=NULL,
+start=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -70,23 +72,31 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlOl(list(
-      htmlLi("Un"),
-      htmlLi("Deux"),
-      htmlLi("Trois")
+  app$layout(
+    htmlDiv(list(
+      htmlOl(list(
+        htmlLi("Un"),
+        htmlLi("Deux"),
+        htmlLi("Trois")
+      ))
     ))
-  ))
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlOptgroup.Rd
+++ b/man/htmlOptgroup.Rd
@@ -10,11 +10,13 @@ Optgroup is a wrapper for the <optgroup> HTML5 element. For detailed attribute i
 }
 
 \usage{
-htmlOptgroup(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, disabled=NULL, label=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlOptgroup(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, disabled=NULL,
+label=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -70,29 +72,37 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlLabel(
-      htmlFor = "option-select", "Please select car brand/model: "
-    ),
-    htmlSelect(id = "option-select", list(
-    htmlOptgroup("Audi"), #label = "Audi"
-    htmlOption("TT"),
-    htmlOption("A4"),
-    htmlOptgroup("BMW"), #label = "BMW"
-    htmlOption("3 Series"),
-    htmlOption("5 Series")
+  app$layout(
+    htmlDiv(list(
+      htmlLabel(
+        htmlFor = "option-select", "Please select car brand/model: "
+      ),
+      htmlSelect(id = "option-select", list(
+      htmlOptgroup("Audi"), #label = "Audi"
+      htmlOption("TT"),
+      htmlOption("A4"),
+      htmlOptgroup("BMW"), #label = "BMW"
+      htmlOption("3 Series"),
+      htmlOption("5 Series")
+      ))
     ))
-  ))
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlOption.Rd
+++ b/man/htmlOption.Rd
@@ -10,11 +10,13 @@ Option is a wrapper for the <option> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlOption(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, disabled=NULL, label=NULL, selected=NULL, value=NULL, accessKey=NULL,
-className=NULL, contentEditable=NULL, contextMenu=NULL, dir=NULL,
-draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlOption(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, disabled=NULL,
+label=NULL, selected=NULL, value=NULL, accessKey=NULL,
+className=NULL, contentEditable=NULL, contextMenu=NULL,
+dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
+spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
+loading_state=NULL, ...)
 }
 
 \arguments{
@@ -74,24 +76,32 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlSelect(list(
-      htmlOption("d'Artagnan"),
-      htmlOption("Athos"),
-      htmlOption("Porthos"),
-      htmlOption("Aramis")
+  app$layout(
+    htmlDiv(list(
+      htmlSelect(list(
+        htmlOption("d'Artagnan"),
+        htmlOption("Athos"),
+        htmlOption("Porthos"),
+        htmlOption("Aramis")
+      ))
     ))
-  ))
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlOutput.Rd
+++ b/man/htmlOutput.Rd
@@ -10,11 +10,13 @@ Output is a wrapper for the <output> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlOutput(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, htmlFor=NULL, form=NULL, name=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlOutput(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, htmlFor=NULL,
+form=NULL, name=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -72,8 +74,16 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# This component works with htmlForm and htmlInput and may be used to present the result of an executed script.
-}}
+# This component works with htmlForm and htmlInput 
+# and may be used to present the result of an
+# executed script.
+}

--- a/man/htmlP.Rd
+++ b/man/htmlP.Rd
@@ -10,10 +10,12 @@ P is a wrapper for the <p> HTML5 element. For detailed attribute info see: https
 }
 
 \usage{
-htmlP(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlP(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,19 +67,27 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP("The <p> tag defines a paragraph.")
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlP("The <p> tag defines a paragraph.")
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlParam.Rd
+++ b/man/htmlParam.Rd
@@ -10,11 +10,13 @@ Param is a wrapper for the <param> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlParam(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, name=NULL, value=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlParam(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, name=NULL,
+value=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -70,25 +72,33 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP("The <param> element is used to specify the parameters that apply to
-    plugin-powered content embedded with an <object> element.
-    Read more: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param"),
-    htmlObjectEl(
-      #data = "link-to-data-file"
-      htmlParam(name = "controller", value = TRUE)
-    )
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlP("The <param> element is used to specify the parameters that apply to
+      plugin-powered content embedded with an <object> element.
+      Read more: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param"),
+      htmlObjectEl(
+        #data = "link-to-data-file"
+        htmlParam(name = "controller", value = TRUE)
+      )
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlPicture.Rd
+++ b/man/htmlPicture.Rd
@@ -10,10 +10,12 @@ Picture is a wrapper for the <picture> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlPicture(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlPicture(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,24 +67,41 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+# The URL below has been chunked to comply with CRAN
+# requirements; the use of file.path is optional and not required
+# for this component.
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlPicture(list(
-      htmlSource(srcSet = "https://upload.wikimedia.org/wikipedia/commons/a/a7/Winter_and_the_City.jpg",
-                 media = "(min-width: 800px)"),
-      htmlImg(src = "https://upload.wikimedia.org/wikipedia/commons/5/56/Summer_and_the_City.jpg"),
-      htmlP("Resize screen to see image changing...")
+  app$layout(
+    htmlDiv(list(
+      htmlPicture(list(
+        htmlSource(srcSet = file.path("https://upload.wikimedia.org",
+                                      "wikipedia/commons/a/a7",
+                                      "Winter_and_the_City.jpg",
+                                      fsep = "/"),
+                  media = "(min-width: 800px)"),
+        htmlImg(src = file.path("https://upload.wikimedia.org",
+                                      "wikipedia/commons/5/56",
+                                      "Summer_and_the_City.jpg",
+                                      fsep = "/")),
+        htmlP("Resize screen to see image changing...")
+      ))
     ))
-  ))
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlPlaintext.Rd
+++ b/man/htmlPlaintext.Rd
@@ -10,10 +10,12 @@ Plaintext is a wrapper for the <plaintext> HTML5 element. For detailed attribute
 }
 
 \usage{
-htmlPlaintext(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlPlaintext(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,27 +67,35 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-# Warning: The <plaintext> tag is obsolete,
-# it might not work as intended.
-# Use the <pre> tag instead.
+if (interactive() && require(dash)) {
+  # Warning: The <plaintext> tag is obsolete,
+  # it might not work as intended.
+  # Use the <pre> tag instead.
 
-library(dash)
-library(dashHtmlComponents)
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlPlaintext(),
-    htmlBr(),
-    htmlH4("The HTML Plaintext Element (<plaintext>) renders everything following
-          the start tag as raw text, ignoring any following HTML. There is no closing tag,
-          since everything after it is considered raw text.")
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlPlaintext(),
+      htmlBr(),
+      htmlH4("The HTML Plaintext Element (<plaintext>) renders everything following
+            the start tag as raw text, ignoring any following HTML. There is no closing tag,
+            since everything after it is considered raw text.")
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlPre.Rd
+++ b/man/htmlPre.Rd
@@ -10,10 +10,12 @@ Pre is a wrapper for the <pre> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlPre(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlPre(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,25 +67,33 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlPre(
-      "
-      Text in a <pre> element is displayed
-      in a fixed-width font (usually Courier),
-      and it preserves both spaces and line breaks.
-      "
-    )
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlPre(
+        "
+        Text in a <pre> element is displayed
+        in a fixed-width font (usually Courier),
+        and it preserves both spaces and line breaks.
+        "
+      )
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlProgress.Rd
+++ b/man/htmlProgress.Rd
@@ -10,11 +10,13 @@ Progress is a wrapper for the <progress> HTML5 element. For detailed attribute i
 }
 
 \usage{
-htmlProgress(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, form=NULL, max=NULL, value=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlProgress(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, form=NULL,
+max=NULL, value=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -72,20 +74,28 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP("Below is an example of htmlProgress"),
-    htmlProgress(value = 80, max = 100)
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlP("Below is an example of htmlProgress"),
+      htmlProgress(value = 80, max = 100)
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlQ.Rd
+++ b/man/htmlQ.Rd
@@ -10,10 +10,12 @@ Q is a wrapper for the <q> HTML5 element. For detailed attribute info see: https
 }
 
 \usage{
-htmlQ(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, cite=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlQ(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, cite=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -67,22 +69,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP(list(
-    "The <q> tag defines a short quotation: ",
-    htmlQ("This example text is wrapped in htmlQ")
+  app$layout(
+    htmlDiv(list(
+      htmlP(list(
+      "The <q> tag defines a short quotation: ",
+      htmlQ("This example text is wrapped in htmlQ")
+      ))
     ))
-  ))
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlRb.Rd
+++ b/man/htmlRb.Rd
@@ -10,10 +10,12 @@ Rb is a wrapper for the <rb> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlRb(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlRb(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,30 +67,38 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlRuby(list(
-      "\U{6f22}",
-      htmlRp("("),
-      htmlRt("kan"),
-      htmlRp(")")
-    )),
-    htmlRuby(list(
-      "\U{5b57}",
-      htmlRp("("),
-      htmlRt("ji"),
-      htmlRp(")")
+  app$layout(
+    htmlDiv(list(
+      htmlRuby(list(
+        "\U{6f22}",
+        htmlRp("("),
+        htmlRt("kan"),
+        htmlRp(")")
+      )),
+      htmlRuby(list(
+        "\U{5b57}",
+        htmlRp("("),
+        htmlRt("ji"),
+        htmlRp(")")
+      ))
     ))
-  ))
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlRp.Rd
+++ b/man/htmlRp.Rd
@@ -10,10 +10,12 @@ Rp is a wrapper for the <rp> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlRp(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlRp(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,30 +67,38 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlRuby(list(
-      "\U{6f22}",
-      htmlRp("("),
-      htmlRt("kan"),
-      htmlRp(")")
-    )),  
-    htmlRuby(list(
-      "\U{5b57}",
-      htmlRp("("),
-      htmlRt("ji"),
-      htmlRp(")")
+  app$layout(
+    htmlDiv(list(
+      htmlRuby(list(
+        "\U{6f22}",
+        htmlRp("("),
+        htmlRt("kan"),
+        htmlRp(")")
+      )),  
+      htmlRuby(list(
+        "\U{5b57}",
+        htmlRp("("),
+        htmlRt("ji"),
+        htmlRp(")")
+      ))   
     ))   
-  ))   
-)    
+  )    
 
-app$run_server()    
-}}
+  app$run_server()
+}
+}

--- a/man/htmlRt.Rd
+++ b/man/htmlRt.Rd
@@ -10,10 +10,12 @@ Rt is a wrapper for the <rt> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlRt(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlRt(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,30 +67,38 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlRuby(list(
-      "\U{6f22}",
-      htmlRp("("),
-      htmlRt("kan"),
-      htmlRp(")")
-    )),  
-    htmlRuby(list(
-      "\U{5b57}",
-      htmlRp("("),
-      htmlRt("ji"),
-      htmlRp(")")
+  app$layout(
+    htmlDiv(list(
+      htmlRuby(list(
+        "\U{6f22}",
+        htmlRp("("),
+        htmlRt("kan"),
+        htmlRp(")")
+      )),  
+      htmlRuby(list(
+        "\U{5b57}",
+        htmlRp("("),
+        htmlRt("ji"),
+        htmlRp(")")
+      ))   
     ))   
-  ))   
-)    
+  )    
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlRtc.Rd
+++ b/man/htmlRtc.Rd
@@ -10,10 +10,12 @@ Rtc is a wrapper for the <rtc> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlRtc(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlRtc(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,22 +67,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlRuby(list(
-      "\U2661",
-      htmlRtc(htmlRt('Heart"))
+  app$layout(
+    htmlDiv(list(
+      htmlRuby(list(
+        "\U2661",
+        htmlRtc(htmlRt("Heart"))
+      ))
     ))
-  ))
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlRuby.Rd
+++ b/man/htmlRuby.Rd
@@ -10,10 +10,12 @@ Ruby is a wrapper for the <ruby> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlRuby(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlRuby(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,19 +67,27 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlRuby("\U{54d0}")
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlRuby("\U{54d0}")
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlS.Rd
+++ b/man/htmlS.Rd
@@ -10,10 +10,12 @@ S is a wrapper for the <s> HTML5 element. For detailed attribute info see: https
 }
 
 \usage{
-htmlS(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlS(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlS("htmlS  generates strikethrough text"),
-    htmlP(),
-    htmlB("htmlB  generates bold text")
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlS("htmlS  generates strikethrough text"),
+      htmlP(),
+      htmlB("htmlB  generates bold text")
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlSamp.Rd
+++ b/man/htmlSamp.Rd
@@ -10,10 +10,12 @@ Samp is a wrapper for the <samp> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlSamp(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlSamp(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,19 +67,27 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlSamp("htmlSamp formats text to computer program output.")
-  ))
-)
+  app$layout(
+    htmlDiv(list(
+      htmlSamp("htmlSamp formats text to computer program output.")
+    ))
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlScript.Rd
+++ b/man/htmlScript.Rd
@@ -10,12 +10,14 @@ Script is a wrapper for the <script> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlScript(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, async=NULL, charSet=NULL, crossOrigin=NULL, defer=NULL,
-integrity=NULL, src=NULL, type=NULL, accessKey=NULL, className=NULL,
-contentEditable=NULL, contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
-lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
-loading_state=NULL)
+htmlScript(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, async=NULL,
+charSet=NULL, crossOrigin=NULL, defer=NULL, integrity=NULL,
+src=NULL, type=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -81,10 +83,16 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # This component is retained for compatibility reasons, but we suggest
 # using Dash's capability for embedding scripts within the assets folder
 # instead.
-}}
+}

--- a/man/htmlSection.Rd
+++ b/man/htmlSection.Rd
@@ -10,10 +10,12 @@ Section is a wrapper for the <section> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlSection(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlSection(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,25 +67,33 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlSection(
-      children = list(
-        htmlH1("This is a section title"),
-        htmlDiv("This is some text within a section")
+  app$layout(
+    htmlDiv(list(
+      htmlSection(
+        children = list(
+          htmlH1("This is a section title"),
+          htmlDiv("This is some text within a section")
+        )
+      )
       )
     )
-    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlSelect.Rd
+++ b/man/htmlSelect.Rd
@@ -10,12 +10,14 @@ Select is a wrapper for the <select> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlSelect(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, autoComplete=NULL, autoFocus=NULL, disabled=NULL, form=NULL,
-multiple=NULL, name=NULL, required=NULL, size=NULL, accessKey=NULL,
-className=NULL, contentEditable=NULL, contextMenu=NULL, dir=NULL,
-draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlSelect(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+autoComplete=NULL, autoFocus=NULL, disabled=NULL, form=NULL,
+multiple=NULL, name=NULL, required=NULL, size=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -83,26 +85,34 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlSelect(
-      children = list(
-        htmlOption("This is an option in htmlSelect"),
-        htmlOption("But you might want to check out dccDropdown as well"),
-        htmlOption("dccDropdown is part of the dashCoreComponents library")
+  app$layout(
+    htmlDiv(list(
+      htmlSelect(
+        children = list(
+          htmlOption("This is an option in htmlSelect"),
+          htmlOption("But you might want to check out dccDropdown as well"),
+          htmlOption("dccDropdown is part of the dashCoreComponents library")
+        )
+      )
       )
     )
-    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlShadow.Rd
+++ b/man/htmlShadow.Rd
@@ -10,10 +10,12 @@ Shadow is a wrapper for the <shadow> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlShadow(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlShadow(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,9 +67,15 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # The Shadow element requires a browser that supports
 # Web Components. It is experimental and should be used
 # with caution; it is now considered an obsolete element
@@ -75,4 +83,4 @@ those elements have the following types:
 # solely for backwards compatibility reasons.
 #
 # For more information, please see the MDN link above.
-}}
+}

--- a/man/htmlSlot.Rd
+++ b/man/htmlSlot.Rd
@@ -10,10 +10,12 @@ Slot is a wrapper for the <slot> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlSlot(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlSlot(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,10 +67,16 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # Please see https://mdn.github.io/web-components-examples/element-details/
 # and https://github.com/mdn/web-components-examples/tree/master/element-details
 # for a useful example of this element (with accompanying JavaScript) in action.
-}}
+}

--- a/man/htmlSmall.Rd
+++ b/man/htmlSmall.Rd
@@ -10,10 +10,12 @@ Small is a wrapper for the <small> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlSmall(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlSmall(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,22 +67,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "This is normal text",
-    htmlBr(),
-    htmlSmall("And this is text in an htmlSmall component")
+  app$layout(
+    htmlDiv(list(
+      "This is normal text",
+      htmlBr(),
+      htmlSmall("And this is text in an htmlSmall component")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlSource.Rd
+++ b/man/htmlSource.Rd
@@ -10,11 +10,13 @@ Source is a wrapper for the <source> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlSource(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, media=NULL, sizes=NULL, src=NULL, srcSet=NULL, type=NULL,
-accessKey=NULL, className=NULL, contentEditable=NULL, contextMenu=NULL,
-dir=NULL, draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlSource(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, media=NULL,
+sizes=NULL, src=NULL, srcSet=NULL, type=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -76,32 +78,43 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+# The URL below has been chunked to comply with CRAN
+# requirements; the use of file.path is optional and not required
+# for this component.
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-      "Resize your browser window to see the image source change based based on the browser width",
-      htmlBr(),
-      htmlPicture(
-        list(
-          htmlSource(
-            media = "(min-width: 1000px)",
-            srcSet = "https://apod.nasa.gov/apod/image/1907/FishheadNebula_Pham_2401.jpg"
-          ),
-          htmlImg(
-            src = "https://apod.nasa.gov/apod/image/1907/ngc3576_campbell_1824.jpg"
+  app$layout(
+    htmlDiv(list(
+        "Resize your browser window to see the image source change based on the browser width",
+        htmlBr(),
+        htmlPicture(
+          list(
+            htmlSource(
+              media = "(min-width: 1000px)",
+              srcSet = "https://apod.nasa.gov/apod/image/1907/FishheadNebula_Pham_2401.jpg"
+            ),
+            htmlImg(
+              src = "https://apod.nasa.gov/apod/image/1907/ngc3576_campbell_1824.jpg"
+            )
           )
         )
       )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()              
+}
+}

--- a/man/htmlSpacer.Rd
+++ b/man/htmlSpacer.Rd
@@ -10,10 +10,12 @@ Spacer is a wrapper for the <spacer> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlSpacer(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlSpacer(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,10 +67,16 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # This component provides an HTML element that is now obsolete
 # and not supported by modern web browsers; it is retained for
 # backwards compatibility.
-}}
+}

--- a/man/htmlSpan.Rd
+++ b/man/htmlSpan.Rd
@@ -10,10 +10,12 @@ Span is a wrapper for the <span> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlSpan(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlSpan(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,25 +67,33 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "This is some text",
-    htmlBr(),
-    htmlSpan(
-      children = "And some text within an italicized span",
-      style = list(fontStyle = "italic")
-    )
+  app$layout(
+    htmlDiv(list(
+      "This is some text",
+      htmlBr(),
+      htmlSpan(
+        children = "And some text within an italicized span",
+        style = list(fontStyle = "italic")
+      )
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlStrike.Rd
+++ b/man/htmlStrike.Rd
@@ -10,10 +10,12 @@ Strike is a wrapper for the <strike> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlStrike(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlStrike(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "This is normal text",
-    htmlStrike("Text within an htmlStrike element will be stricken out")
+  app$layout(
+    htmlDiv(list(
+      "This is normal text",
+      htmlStrike("Text within an htmlStrike element will be stricken out")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlStrong.Rd
+++ b/man/htmlStrong.Rd
@@ -10,10 +10,12 @@ Strong is a wrapper for the <strong> HTML5 element. For detailed attribute info 
 }
 
 \usage{
-htmlStrong(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlStrong(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,22 +67,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "This is normal text",
-    htmlBr(),
-    htmlStrong("Text within an htmlStrong element will be Bold")
+  app$layout(
+    htmlDiv(list(
+      "This is normal text",
+      htmlBr(),
+      htmlStrong("Text within an htmlStrong element will be Bold")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlSub.Rd
+++ b/man/htmlSub.Rd
@@ -10,10 +10,12 @@ Sub is a wrapper for the <sub> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlSub(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlSub(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "This is normal text ",
-    htmlSub("And this is subscript text within an htmlSub")
+  app$layout(
+    htmlDiv(list(
+      "This is normal text ",
+      htmlSub("And this is subscript text within an htmlSub")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlSummary.Rd
+++ b/man/htmlSummary.Rd
@@ -10,10 +10,12 @@ Summary is a wrapper for the <summary> HTML5 element. For detailed attribute inf
 }
 
 \usage{
-htmlSummary(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlSummary(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,27 +67,35 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlDetails(
-      children = list(
-        htmlSummary(
-          children = "Within a details element, the summary can act as a clickable description"
-        ),
-        "And the rest is hidden until the summary is clicked"
+  app$layout(
+    htmlDiv(list(
+      htmlDetails(
+        children = list(
+          htmlSummary(
+            children = "Within a details element, the summary can act as a clickable description"
+          ),
+          "And the rest is hidden until the summary is clicked"
+        )
+      )
       )
     )
-    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlSup.Rd
+++ b/man/htmlSup.Rd
@@ -10,10 +10,12 @@ Sup is a wrapper for the <sup> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlSup(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlSup(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,21 +67,29 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "This is normal text",
-    htmlSup("And this is superscript text within an htmlSup")
+  app$layout(
+    htmlDiv(list(
+      "This is normal text",
+      htmlSup("And this is superscript text within an htmlSup")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlTable.Rd
+++ b/man/htmlTable.Rd
@@ -10,10 +10,12 @@ Table is a wrapper for the <table> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlTable(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, summary=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlTable(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, summary=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -67,37 +69,45 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "You can create a table with htmlTable:",
-    htmlBr(),
-    htmlTable(
-      list(
-        htmlTr(
-          list(
-            htmlTh("Table Header 1"),
-            htmlTh("Table Header 2")
-          )
-        ),
-        htmlTr(
-          list(
-            htmlTd("row 1 under Header 1"),
-            htmlTd("row 1 under Header 2")
+  app$layout(
+    htmlDiv(list(
+      "You can create a table with htmlTable:",
+      htmlBr(),
+      htmlTable(
+        list(
+          htmlTr(
+            list(
+              htmlTh("Table Header 1"),
+              htmlTh("Table Header 2")
+            )
+          ),
+          htmlTr(
+            list(
+              htmlTd("row 1 under Header 1"),
+              htmlTd("row 1 under Header 2")
+            )
           )
         )
       )
-    )
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlTbody.Rd
+++ b/man/htmlTbody.Rd
@@ -10,10 +10,12 @@ Tbody is a wrapper for the <tbody> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlTbody(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlTbody(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,40 +67,48 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "Within an htmlTable, you can specify the rows that go in the body of the table with htmlTbody",
-    htmlBr(),
-    htmlTable(
-      list(
-        htmlThead(
-          htmlTr(
-            htmlTh("This is in the header of the table")
-          )
-        ),
-        htmlTbody(
-          htmlTr(
-            htmlTd("This is in the body of the table")
-          )
-        ),
-        htmlTfoot(
-          htmlTr(
-            htmlTd("This is in the footer of the table")
+  app$layout(
+    htmlDiv(list(
+      "Within an htmlTable, htmlTbody specifies rows for the table body",
+      htmlBr(),
+      htmlTable(
+        list(
+          htmlThead(
+            htmlTr(
+              htmlTh("This is in the header of the table")
+            )
+          ),
+          htmlTbody(
+            htmlTr(
+              htmlTd("This is in the body of the table")
+            )
+          ),
+          htmlTfoot(
+            htmlTr(
+              htmlTd("This is in the footer of the table")
+            )
           )
         )
       )
-    )
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlTd.Rd
+++ b/man/htmlTd.Rd
@@ -10,11 +10,13 @@ Td is a wrapper for the <td> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlTd(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, colSpan=NULL, headers=NULL, rowSpan=NULL, accessKey=NULL,
-className=NULL, contentEditable=NULL, contextMenu=NULL, dir=NULL,
-draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlTd(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, colSpan=NULL,
+headers=NULL, rowSpan=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -72,37 +74,45 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "Within an htmlTable, individual cells can be made with htmlTd",
-    htmlBr(),
-    htmlTable(
-      list(
-        htmlTr(
-          list(
-            htmlTh("Header 1"),
-            htmlTh("Header 2")
-          )
-        ),
-        htmlTr(
-          list(
-            htmlTd("this is a cell"),
-            htmlTd("this is another cell")
+  app$layout(
+    htmlDiv(list(
+      "Within an htmlTable, individual cells can be made with htmlTd",
+      htmlBr(),
+      htmlTable(
+        list(
+          htmlTr(
+            list(
+              htmlTh("Header 1"),
+              htmlTh("Header 2")
+            )
+          ),
+          htmlTr(
+            list(
+              htmlTd("this is a cell"),
+              htmlTd("this is another cell")
+            )
           )
         )
       )
-    )
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlTemplate.Rd
+++ b/man/htmlTemplate.Rd
@@ -10,10 +10,12 @@ Template is a wrapper for the <template> HTML5 element. For detailed attribute i
 }
 
 \usage{
-htmlTemplate(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlTemplate(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,39 +67,47 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "You can create an HTML template to be populated later via js",
-    htmlBr(),
-    htmlTable(
-      id = "myTable",
-      htmlTr(
-        list(
-          htmlTh("Header 1"),
-          htmlTh("Header 2")
+  app$layout(
+    htmlDiv(list(
+      "You can create an HTML template to be populated later via js",
+      htmlBr(),
+      htmlTable(
+        id = "myTable",
+        htmlTr(
+          list(
+            htmlTh("Header 1"),
+            htmlTh("Header 2")
+          )
+        )
+      ),
+      htmlTemplate(
+        id = "myRowTemplate",
+        htmlTr(
+          list(
+            htmlTd(className = "someRowValue"),
+            htmlTd()
+          )
         )
       )
-    ),
-    htmlTemplate(
-      id = "myRowTemplate",
-      htmlTr(
-        list(
-          htmlTd(className = "someRowValue"),
-          htmlTd()
-        )
       )
-    )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlTextarea.Rd
+++ b/man/htmlTextarea.Rd
@@ -10,13 +10,16 @@ Textarea is a wrapper for the <textarea> HTML5 element. For detailed attribute i
 }
 
 \usage{
-htmlTextarea(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, autoComplete=NULL, autoFocus=NULL, cols=NULL, disabled=NULL,
-form=NULL, inputMode=NULL, maxLength=NULL, minLength=NULL, name=NULL,
-placeholder=NULL, readOnly=NULL, required=NULL, rows=NULL, wrap=NULL,
-accessKey=NULL, className=NULL, contentEditable=NULL, contextMenu=NULL,
-dir=NULL, draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlTextarea(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+autoComplete=NULL, autoFocus=NULL, cols=NULL, disabled=NULL,
+form=NULL, inputMode=NULL, maxLength=NULL, minLength=NULL,
+name=NULL, placeholder=NULL, readOnly=NULL, required=NULL,
+rows=NULL, wrap=NULL, accessKey=NULL, className=NULL,
+contentEditable=NULL, contextMenu=NULL, dir=NULL,
+draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL,
+style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL,
+...)
 }
 
 \arguments{
@@ -96,23 +99,31 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlTextarea(
-      rows = 4, cols = 50,
-      children = "A text area allows users to input text"
-    )
+  app$layout(
+    htmlDiv(list(
+      htmlTextarea(
+        rows = 4, cols = 50,
+        children = "A text area allows users to input text"
+      )
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlTfoot.Rd
+++ b/man/htmlTfoot.Rd
@@ -10,10 +10,12 @@ Tfoot is a wrapper for the <tfoot> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlTfoot(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlTfoot(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,40 +67,48 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "Within an htmlTable, you can create footer rows with htmlTfoot",
-    htmlBr(),
-    htmlTable(
-      list(
-        htmlThead(
-          htmlTr(
-            htmlTh("This is in the header of the table")
-          )
-        ),
-        htmlTbody(
-          htmlTr(
-            htmlTd("This is in the body of the table")
-          )
-        ),
-        htmlTfoot(
-          htmlTr(
-            htmlTd("This is in the footer of the table")
+  app$layout(
+    htmlDiv(list(
+      "Within an htmlTable, you can create footer rows with htmlTfoot",
+      htmlBr(),
+      htmlTable(
+        list(
+          htmlThead(
+            htmlTr(
+              htmlTh("This is in the header of the table")
+            )
+          ),
+          htmlTbody(
+            htmlTr(
+              htmlTd("This is in the body of the table")
+            )
+          ),
+          htmlTfoot(
+            htmlTr(
+              htmlTd("This is in the footer of the table")
+            )
           )
         )
       )
-    )
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlTh.Rd
+++ b/man/htmlTh.Rd
@@ -10,11 +10,13 @@ Th is a wrapper for the <th> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlTh(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, colSpan=NULL, headers=NULL, rowSpan=NULL, scope=NULL, accessKey=NULL,
-className=NULL, contentEditable=NULL, contextMenu=NULL, dir=NULL,
-draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlTh(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, colSpan=NULL,
+headers=NULL, rowSpan=NULL, scope=NULL, accessKey=NULL,
+className=NULL, contentEditable=NULL, contextMenu=NULL,
+dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
+spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL,
+loading_state=NULL, ...)
 }
 
 \arguments{
@@ -74,30 +76,38 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlTable(
-      list(
-        # the following row contains headers
-        htmlTr(
-          list(
-            htmlTh("Header 1"),
-            htmlTh("Header 2")
+  app$layout(
+    htmlDiv(list(
+      htmlTable(
+        list(
+          # the following row contains headers
+          htmlTr(
+            list(
+              htmlTh("Header 1"),
+              htmlTh("Header 2")
+            )
           )
         )
       )
-    )
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlThead.Rd
+++ b/man/htmlThead.Rd
@@ -10,10 +10,12 @@ Thead is a wrapper for the <thead> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlThead(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlThead(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,40 +67,48 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "Within an htmlTable, you can create a header with htmlThead",
-    htmlBr(),
-    htmlTable(
-      list(
-        htmlThead(
-          htmlTr(
-            htmlTh("This is in the header of the table")
-          )
-        ),
-        htmlTbody(
-          htmlTr(
-            htmlTd("This is in the body of the table")
-          )
-        ),
-        htmlTfoot(
-          htmlTr(
-            htmlTd("This is in the footer of the table")
+  app$layout(
+    htmlDiv(list(
+      "Within an htmlTable, you can create a header with htmlThead",
+      htmlBr(),
+      htmlTable(
+        list(
+          htmlThead(
+            htmlTr(
+              htmlTh("This is in the header of the table")
+            )
+          ),
+          htmlTbody(
+            htmlTr(
+              htmlTd("This is in the body of the table")
+            )
+          ),
+          htmlTfoot(
+            htmlTr(
+              htmlTd("This is in the footer of the table")
+            )
           )
         )
       )
-    )
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlTime.Rd
+++ b/man/htmlTime.Rd
@@ -10,10 +10,12 @@ Time is a wrapper for the <time> HTML5 element. For detailed attribute info see:
 }
 
 \usage{
-htmlTime(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, dateTime=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlTime(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, dateTime=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -67,26 +69,34 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlP(
-      list(
-        "It might be useful to wrap dates like ",
-        htmlTime(dateTime = "2019-07-29", children = "July 29th"),
-        " in an htmlTime to make your datetime strings machine-readable."
+  app$layout(
+    htmlDiv(list(
+      htmlP(
+        list(
+          "It might be useful to wrap dates like ",
+          htmlTime(dateTime = "2019-07-29", children = "July 29th"),
+          " in an htmlTime to make your datetime strings machine-readable."
+        )
+      )
       )
     )
-    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlTitle.Rd
+++ b/man/htmlTitle.Rd
@@ -10,10 +10,12 @@ Title is a wrapper for the <title> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlTitle(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlTitle(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,12 +67,18 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
 # This component's effects will be overridden by the index
 # template in Dash for R. We suggest using Dash's API to
 # set the page title instead:
 #
 # app$title('My page title')
-}}
+}

--- a/man/htmlTr.Rd
+++ b/man/htmlTr.Rd
@@ -10,10 +10,12 @@ Tr is a wrapper for the <tr> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlTr(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlTr(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,39 +67,47 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "Within an htmlTable, individual rows can be made with htmlTr",
-    htmlBr(),
-    htmlTable(
-      list(
-        # the following row contains headers
-        htmlTr(
-          list(
-            htmlTh("Header 1"),
-            htmlTh("Header 2")
-          )
-        ),
-        # the following row contains cells
-        htmlTr(
-          list(
-            htmlTd("this is a cell"),
-            htmlTd("this is another cell")
+  app$layout(
+    htmlDiv(list(
+      "Within an htmlTable, individual rows can be made with htmlTr",
+      htmlBr(),
+      htmlTable(
+        list(
+          # the following row contains headers
+          htmlTr(
+            list(
+              htmlTh("Header 1"),
+              htmlTh("Header 2")
+            )
+          ),
+          # the following row contains cells
+          htmlTr(
+            list(
+              htmlTd("this is a cell"),
+              htmlTd("this is another cell")
+            )
           )
         )
       )
-    )
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlTrack.Rd
+++ b/man/htmlTrack.Rd
@@ -10,11 +10,13 @@ Track is a wrapper for the <track> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlTrack(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, default=NULL, kind=NULL, label=NULL, src=NULL, srcLang=NULL,
-accessKey=NULL, className=NULL, contentEditable=NULL, contextMenu=NULL,
-dir=NULL, draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlTrack(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, default=NULL,
+kind=NULL, label=NULL, src=NULL, srcLang=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -76,25 +78,47 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+# The URL below has been chunked to comply with CRAN
+# requirements; the use of file.path is optional and not required
+# for this component.
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlVideo(children = list(
-      htmlSource(src = 'https://interactive-examples.mdn.mozilla.net/media/examples/friday.mp4', type = 'video/mp4'),
-      htmlTrack(kind = 'captions', srcLang = 'en', src = 'https://interactive-examples.mdn.mozilla.net/media/examples/friday.vtt', default = 'default', label = 'English')
-    ),
-    controls = TRUE
-   )
+  app$layout(
+    htmlDiv(list(
+      htmlVideo(children = list(
+        htmlSource(src = file.path("https://interactive-examples.mdn.mozilla.net",
+                                  "media/examples",
+                                  "friday.mp4",
+                                  fsep = "/"), 
+                  type = 'video/mp4'),
+        htmlTrack(kind = 'captions',
+                  srcLang = 'en',
+                  src = file.path("https://interactive-examples.mdn.mozilla.net",
+                                  "media/examples",
+                                  "friday.vtt",
+                                  fsep = "/"), 
+                  default = 'default',
+                  label = 'English')
+      ),
+      controls = TRUE
+    )
+    )
   )
- )
-)
+  )
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlU.Rd
+++ b/man/htmlU.Rd
@@ -10,10 +10,12 @@ U is a wrapper for the <u> HTML5 element. For detailed attribute info see: https
 }
 
 \usage{
-htmlU(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlU(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,20 +67,28 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlU("Wrap your text in htmlU to have it underlined")
+  app$layout(
+    htmlDiv(list(
+      htmlU("Wrap your text in htmlU to have it underlined")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlUl.Rd
+++ b/man/htmlUl.Rd
@@ -10,10 +10,12 @@ Ul is a wrapper for the <ul> HTML5 element. For detailed attribute info see: htt
 }
 
 \usage{
-htmlUl(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlUl(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,27 +67,35 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "You can make an unordered list with htmlUl",
-    htmlBr(),
-    htmlUl(
-      children = list(
-        htmlLi("Some item"),
-        htmlLi("Some other item")
+  app$layout(
+    htmlDiv(list(
+      "You can make an unordered list with htmlUl",
+      htmlBr(),
+      htmlUl(
+        children = list(
+          htmlLi("Some item"),
+          htmlLi("Some other item")
+        )
+      )
       )
     )
-    )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlVar.Rd
+++ b/man/htmlVar.Rd
@@ -10,10 +10,12 @@ Var is a wrapper for the <var> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlVar(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlVar(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,22 +67,30 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "You can use htmlVar to represent the name of a variable",
-    htmlBr(),
-    htmlVar("myVariable")
+  app$layout(
+    htmlDiv(list(
+      "You can use htmlVar to represent the name of a variable",
+      htmlBr(),
+      htmlVar("myVariable")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlVideo.Rd
+++ b/man/htmlVideo.Rd
@@ -10,12 +10,14 @@ Video is a wrapper for the <video> HTML5 element. For detailed attribute info se
 }
 
 \usage{
-htmlVideo(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, autoPlay=NULL, controls=NULL, crossOrigin=NULL, height=NULL,
-loop=NULL, muted=NULL, poster=NULL, preload=NULL, src=NULL, width=NULL,
-accessKey=NULL, className=NULL, contentEditable=NULL, contextMenu=NULL,
-dir=NULL, draggable=NULL, hidden=NULL, lang=NULL, spellCheck=NULL, style=NULL,
-tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlVideo(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL, autoPlay=NULL,
+controls=NULL, crossOrigin=NULL, height=NULL, loop=NULL,
+muted=NULL, poster=NULL, preload=NULL, src=NULL, width=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -87,24 +89,35 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlVideo(
-      src = "https://ia800303.us.archive.org/18/items/bacteria_friend_and_foe/bacteria_friend_and_foe_512kb.mp4",
-      controls = TRUE,
-      title = "Bacteria: Friend and Foe"
-    )
+  app$layout(
+    htmlDiv(list(
+      htmlVideo(
+        src = file.path('https://ia800303.us.archive.org',
+              '18/items/bacteria_friend_and_foe',
+              'bacteria_friend_and_foe_512kb.mp4',
+              fsep = '/'),
+        controls = TRUE,
+        title = "Bacteria: Friend and Foe"
+      )
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlWbr.Rd
+++ b/man/htmlWbr.Rd
@@ -10,10 +10,12 @@ Wbr is a wrapper for the <wbr> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlWbr(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlWbr(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,23 +67,31 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    "In a long string, it might be a good idea to add an htmlWbr to specify word breaks",
-    htmlP("Thisverylongstringwithnowhitespaceswon'tlookverygood"),
-    htmlWbr(),
-    htmlP("butatleastyoucanspecifya'natural'placeforthestringtobebrokenup")
+  app$layout(
+    htmlDiv(list(
+      "In a long string, it might be a good idea to add an htmlWbr to specify word breaks",
+      htmlP("Thisverylongstringwithnowhitespaceswon'tlookverygood"),
+      htmlWbr(),
+      htmlP("butatleastyoucanspecifya'natural'placeforthestringtobebrokenup")
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/man/htmlXmp.Rd
+++ b/man/htmlXmp.Rd
@@ -10,10 +10,12 @@ Xmp is a wrapper for the <xmp> HTML5 element. For detailed attribute info see: h
 }
 
 \usage{
-htmlXmp(children=NULL, id=NULL, n_clicks=NULL, n_clicks_timestamp=NULL, key=NULL,
-role=NULL, accessKey=NULL, className=NULL, contentEditable=NULL,
-contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL, lang=NULL,
-spellCheck=NULL, style=NULL, tabIndex=NULL, title=NULL, loading_state=NULL)
+htmlXmp(children=NULL, id=NULL, n_clicks=NULL,
+n_clicks_timestamp=NULL, key=NULL, role=NULL,
+accessKey=NULL, className=NULL, contentEditable=NULL,
+contextMenu=NULL, dir=NULL, draggable=NULL, hidden=NULL,
+lang=NULL, spellCheck=NULL, style=NULL, tabIndex=NULL,
+title=NULL, loading_state=NULL, ...)
 }
 
 \arguments{
@@ -65,25 +67,33 @@ those elements have the following types:
   - is_loading (logical; optional): determines if the component is loading or not
   - prop_name (character; optional): holds which property is loading
   - component_name (character; optional): holds the name of the component that is loading. Object that holds the loading state object coming from dash-renderer}
+
+
+\item{...}{wildcards allowed have the form: `'data-*', 'aria-*'`}
+
 }
+
+\value{named list of JSON elements corresponding to React.js properties and their values}
+
 \examples{
-\dontrun{
-library(dash)
-library(dashHtmlComponents)
+if (interactive() && require(dash)) {
+  library(dash)
+  library(dashHtmlComponents)
 
-app <- Dash$new()
+  app <- Dash$new()
 
-app$layout(
-  htmlDiv(list(
-    htmlXmp("xmp elements will be rendered in monospace font"),
-    htmlXmp("Note that this element is obsolete in HTML5"),
-    htmlA(
-      "See this for more details",
-      href = "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/xmp"
-    )
+  app$layout(
+    htmlDiv(list(
+      htmlXmp("xmp elements will be rendered in monospace font"),
+      htmlXmp("Note that this element is obsolete in HTML5"),
+      htmlA(
+        "See this for more details",
+        href = "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/xmp"
+      )
+      )
     )
   )
-)
 
-app$run_server()
-}}
+  app$run_server()
+}
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "uninstall-local": "pip uninstall dash-html-components -y",
     "lint": "eslint src scripts",
     "build:js": "webpack --mode production",
-    "build:py_and_r": "dash-generate-components ./src/components dash_html_components -p package-info.json && cp dash_html_components_base/** dash_html_components && dash-generate-components ./src/components dash_html_components -p package-info.json --r-prefix 'html'",
+    "build:py_and_r": "dash-generate-components ./src/components dash_html_components -p package-info.json && cp dash_html_components_base/** dash_html_components && dash-generate-components ./src/components dash_html_components -p package-info.json --r-prefix 'html' --r-suggests 'dash,dashCoreComponents'",
     "build": "npm run build:js && npm run build:py_and_r",
     "postbuild": "es-check es5 dash_html_components/*.js",
     "build:watch": "watch 'npm run build' src",


### PR DESCRIPTION
This PR proposes several updates to `dashHtmlComponents` to pass CRAN checks:
- the `dash-info.yaml` present in `dev` is merged into `master`
- the `.Rd` files now include the missing "dots" (`...`) argument for wildcards, which is required to pass CRAN checks
- the `DESCRIPTION` file now contains copyright and `Authors@R`, which is required to pass CRAN checks