### PR TITLE
Update component generation

### DIFF
--- a/scripts/extract-attributes.js
+++ b/scripts/extract-attributes.js
@@ -55,7 +55,10 @@ const attributeMap = supportedAttributes.reduce((map, reactAttribute) => {
  * descriptions and supported elements.
  */
 function extractAttributes($) {
-    const $table = $('#Attribute_list').next('table');
+    const $table = $('#Attribute_list').parent().find('table');
+    if($table.length !== 1) {
+        throw new Error('page structure changed at ' + htmlURL);
+    }
     const attributes = {};
 
     $table.find('tbody tr').each((i, row) => {

--- a/scripts/generate-components.js
+++ b/scripts/generate-components.js
@@ -192,6 +192,9 @@ function generatePropTypes(element, attributes) {
         component_name: PropTypes.string,
     }),
 
+    /**
+     * Dash-assigned callback that gets fired when the element is clicked.
+     */
     'setProps': PropTypes.func`
 }
 


### PR DESCRIPTION
For MDN's new ["Yari"](https://hacks.mozilla.org/2020/12/welcome-yari-mdn-web-docs-has-a-new-platform/) docs system. In the end it's a very minor change to the reference page we're using, just nesting the attribute table inside another div.

While I was at it I added a description for `setProps`, to reduce warnings while building. There are still a few missing description warnings, but they're all also missing on the reference page.

```
Description for A.shape is missing!
Description for Area.shape is missing!
Description for Col.span is missing!
Description for Colgroup.span is missing!
Description for Command.radioGroup is missing!
Description for Iframe.srcDoc is missing!
Description for Img.sizes is missing!
Description for Img.useMap is missing!
Description for Link.sizes is missing!
Description for ObjectEl.useMap is missing!
Description for Source.sizes is missing!
Description for Table.summary is missing!
Description for Track.srcLang is missing!
```