### PR TITLE
Remove references to Docker Hub context within CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,12 +82,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - python-2.7:
-          context:
-            - dash-docker-hub
-      - python-3.6:
-          context:
-            - dash-docker-hub
-      - python-3.7:
-          context:
-            - dash-docker-hub
+      - python-2.7
+      - python-3.6
+      - python-3.7


### PR DESCRIPTION
This PR aims to address "unauthorized" CircleCI errors related to CI builds triggered by updates from community contributors, who do not have access to our organization's context.

@alexcjohnson @Marc-Andre-Rivet 